### PR TITLE
Feature/104 replace letter state with enum

### DIFF
--- a/onchain/src/constants.cairo
+++ b/onchain/src/constants.cairo
@@ -4,7 +4,7 @@ pub mod LetterStates {
     pub const ABSENT: u8 = 2;
 }
 
-#[derive(PartialEq, Drop)]
+#[derive(PartialEq, Copy, Drop, Serde)]
 pub enum LetterState {
     CORRECT,
     PRESENT,

--- a/onchain/src/constants.cairo
+++ b/onchain/src/constants.cairo
@@ -3,3 +3,31 @@ pub mod LetterStates {
     pub const PRESENT: u8 = 1;
     pub const ABSENT: u8 = 2;
 }
+
+#[derive(PartialEq, Drop)]
+pub enum LetterState {
+    CORRECT,
+    PRESENT,
+    ABSENT
+}
+
+pub impl LetterStateIntoU8 of Into<LetterState, u8> {
+    fn into(self: LetterState) -> u8 {
+        match self {
+            LetterState::CORRECT => 0,
+            LetterState::PRESENT => 1,
+            LetterState::ABSENT => 2
+        }
+    }
+}
+
+pub impl U8IntoLetterState of TryInto<u8, LetterState> {
+    fn try_into(self: u8) -> Option<LetterState> {
+        match self {
+            0 => Option::Some(LetterState::CORRECT),
+            1 => Option::Some(LetterState::PRESENT),
+            2 => Option::Some(LetterState::ABSENT),
+            _ => Option::None
+        }
+    }
+}

--- a/onchain/src/constants.cairo
+++ b/onchain/src/constants.cairo
@@ -1,9 +1,3 @@
-pub mod LetterStates {
-    pub const CORRECT: u8 = 0;
-    pub const PRESENT: u8 = 1;
-    pub const ABSENT: u8 = 2;
-}
-
 #[derive(PartialEq, Copy, Drop, Serde)]
 pub enum LetterState {
     CORRECT,

--- a/onchain/src/contracts/dewordle.cairo
+++ b/onchain/src/contracts/dewordle.cairo
@@ -1,6 +1,7 @@
 #[starknet::contract]
 pub mod DeWordle {
     use dewordle::interfaces::{IDeWordle, PlayerStat, DailyPlayerStat};
+    use dewordle::constants::LetterState;
 
     use dewordle::utils::{compare_word, is_correct_word};
     use openzeppelin::access::accesscontrol::{AccessControlComponent};
@@ -110,7 +111,7 @@ pub mod DeWordle {
             self.daily_player_stat.write(caller, new_daily_stat);
         }
 
-        fn submit_guess(ref self: ContractState, guessed_word: ByteArray) -> Option<Span<u8>> {
+        fn submit_guess(ref self: ContractState, guessed_word: ByteArray) -> Option<Span<LetterState>> {
             assert(guessed_word.len() == self.word_len.read().into(), 'Length does not match');
             let caller = starknet::get_caller_address();
             let daily_stat = self.daily_player_stat.read(caller);

--- a/onchain/src/interfaces.cairo
+++ b/onchain/src/interfaces.cairo
@@ -1,4 +1,5 @@
 use starknet::ContractAddress;
+use dewordle::constants::LetterState;
 
 #[starknet::interface]
 pub trait IDeWordle<TContractState> {
@@ -8,7 +9,7 @@ pub trait IDeWordle<TContractState> {
     fn get_player_daily_stat(self: @TContractState, player: ContractAddress) -> DailyPlayerStat;
     fn play(ref self: TContractState);
 
-    fn submit_guess(ref self: TContractState, guessed_word: ByteArray) -> Option<Span<u8>>;
+    fn submit_guess(ref self: TContractState, guessed_word: ByteArray) -> Option<Span<LetterState>>;
 }
 
 #[derive(Drop, Serde, starknet::Store)]

--- a/onchain/src/utils.cairo
+++ b/onchain/src/utils.cairo
@@ -1,6 +1,6 @@
-use dewordle::constants::LetterStates::{CORRECT, PRESENT, ABSENT};
+use dewordle::constants::LetterState;
 
-pub fn compare_word(word: ByteArray, guessed_word: ByteArray) -> Span<u8> {
+pub fn compare_word(word: ByteArray, guessed_word: ByteArray) -> Span<LetterState> {
     let guessed_word_len = guessed_word.len();
 
     assert(guessed_word_len == word.len(), 'Length does not match');
@@ -30,9 +30,9 @@ pub fn compare_word(word: ByteArray, guessed_word: ByteArray) -> Span<u8> {
     //  Identify exact matches and mark temporary state
     while (i < guessed_word_len) {
         if (guessed_word[i] == word[i]) {
-            temp_states.append(CORRECT); // Letter is in the correct position
+            temp_states.append(LetterState::CORRECT); // Letter is in the correct position
         } else {
-            temp_states.append(ABSENT); // Default to ABSENT for now
+            temp_states.append(LetterState::ABSENT); // Default to ABSENT for now
         }
         i += 1;
     };
@@ -44,12 +44,12 @@ pub fn compare_word(word: ByteArray, guessed_word: ByteArray) -> Span<u8> {
         let prev_word_states = word_states.clone();
         // If the letter was marked ABSENT in the temporary states, check for misplaced
         // occurrences
-        if (*temp_states.at(i) == ABSENT) {
+        if (*temp_states.at(i) == LetterState::ABSENT) {
             let mut j = 0;
             while (j < guessed_word_len) {
                 if (guessed_word[i] == word[j]) {
-                    if (*temp_states.at(j) != CORRECT) {
-                        word_states.append(PRESENT); // Mark as PRESENT (misplaced)
+                    if (*temp_states.at(j) != LetterState::CORRECT) {
+                        word_states.append(LetterState::PRESENT); // Mark as PRESENT (misplaced)
                         break;
                     }
                 }
@@ -58,11 +58,11 @@ pub fn compare_word(word: ByteArray, guessed_word: ByteArray) -> Span<u8> {
 
             // If no match was found, mark as ABSENT
             if (prev_word_states.len() == word_states.len()) {
-                word_states.append(ABSENT);
+                word_states.append(LetterState::ABSENT);
             }
         } else {
             // If the letter was previously marked as CORRECT, preserve the state
-            word_states.append(CORRECT);
+            word_states.append(LetterState::CORRECT);
         }
 
         i += 1;

--- a/onchain/tests/test_constants.cairo
+++ b/onchain/tests/test_constants.cairo
@@ -1,0 +1,25 @@
+use dewordle::constants::{LetterState, LetterStateIntoU8, U8IntoLetterState};
+
+#[test]
+fn test_convert_letterstate_into_u8() {
+
+    assert(LetterState::CORRECT.into() == 0_u8, 'CORRECT must return 0_u8');
+    assert(LetterState::PRESENT.into() == 1_u8, 'PRESENT must return 1_u8');
+    assert(LetterState::ABSENT.into() == 2_u8, 'ABSENT must return 2_u8');
+}
+
+#[test]
+fn test_convert_u8_into_letterstate() {
+
+    let state = 0_u8.try_into().unwrap();
+    assert(state == LetterState::CORRECT, '0_u8 must return CORRECT');
+
+    let state = 1_u8.try_into().unwrap();
+    assert(state == LetterState::PRESENT, '1_u8 must return PRESENT');
+
+    let state = 2_u8.try_into().unwrap();
+    assert(state == LetterState::ABSENT, '2_u8 must return ABSENT');
+
+    let wrong_state:Option<LetterState> = 3_u8.try_into();
+    assert(wrong_state.is_none(), 'others must return Option::None');
+}

--- a/onchain/tests/test_utils.cairo
+++ b/onchain/tests/test_utils.cairo
@@ -1,11 +1,12 @@
 use dewordle::utils::{compare_word, is_correct_word};
+use dewordle::constants::LetterState;
 
 #[test]
 fn test_compare_word_when_all_letters_are_correct() {
     let daily_word = "test";
 
     assert(
-        compare_word(daily_word, "test") == array![0, 0, 0, 0].span(), 'Word not compared correctly'
+        compare_word(daily_word, "test") == array![LetterState::CORRECT, LetterState::CORRECT, LetterState::CORRECT, LetterState::CORRECT].span(), 'Word not compared correctly'
     );
 }
 
@@ -14,7 +15,7 @@ fn test_compare_word_when_some_letters_are_misplaced() {
     let daily_word = "test";
 
     assert(
-        compare_word(daily_word, "tset") == array![0, 1, 1, 0].span(), 'Word not compared correctly'
+        compare_word(daily_word, "tset") == array![LetterState::CORRECT, LetterState::PRESENT, LetterState::PRESENT, LetterState::CORRECT].span(), 'Word not compared correctly'
     );
 }
 
@@ -23,7 +24,7 @@ fn test_compare_word_when_some_letters_are_absent() {
     let daily_word = "test";
 
     assert(
-        compare_word(daily_word, "tsec") == array![0, 1, 1, 2].span(), 'Word not compared correctly'
+        compare_word(daily_word, "tsec") == array![LetterState::CORRECT, LetterState::PRESENT, LetterState::PRESENT, LetterState::ABSENT].span(), 'Word not compared correctly'
     );
 }
 
@@ -40,14 +41,14 @@ fn test_compare_word_when_some_letters_are_repeated() {
     let daily_word = "slept";
 
     assert(
-        compare_word(daily_word, "sweep") == array![0, 2, 0, 2, 1].span(),
+        compare_word(daily_word, "sweep") == array![LetterState::CORRECT, LetterState::ABSENT, LetterState::CORRECT, LetterState::ABSENT, LetterState::PRESENT].span(),
         'Word not compared correctly'
     );
 
     let daily_word = "test";
 
     assert(
-        compare_word(daily_word, "less") == array![2, 0, 0, 2].span(), 'Word not compared correctly'
+        compare_word(daily_word, "less") == array![LetterState::ABSENT, LetterState::CORRECT, LetterState::CORRECT, LetterState::ABSENT].span(), 'Word not compared correctly'
     );
 }
 


### PR DESCRIPTION
Close #104 

Acceptance Criteria

- [x] Define a new enum LetterState with three variants in `constants.cairo`.
- [x] Implement Into<LetterState, u8> and TryInto<u8, LetterState> (is it really necessary).
- [x] Replace all usages of LetterStates constants with the new enum.
- [x] Ensure correctness with unit tests for conversions.