### PR TITLE
feat(auth): Add OTP verification components for forgot password flow

### DIFF
--- a/frontend/app/(auth)/forgotPassword/page.jsx
+++ b/frontend/app/(auth)/forgotPassword/page.jsx
@@ -1,0 +1,7 @@
+import OtpVerification from "../../../components/OtpVerification";
+
+function ForgotPassword() {
+  return <OtpVerification />;
+}
+
+export default ForgotPassword;

--- a/frontend/components/OtpInput.jsx
+++ b/frontend/components/OtpInput.jsx
@@ -1,0 +1,47 @@
+"use client";
+import React, { useState, useRef } from "react";
+
+const OtpInput = ({ length = 4, onComplete }) => {
+  const [otp, setOtp] = useState(new Array(length).fill(""));
+  const inputRefs = useRef([]);
+
+  const handleChange = (index, e) => {
+    const value = e.target.value;
+    if (isNaN(value)) return;
+
+    const newOtp = [...otp];
+    newOtp[index] = value.substring(value.length - 1);
+    setOtp(newOtp);
+
+    if (value && index < length - 1) {
+      inputRefs.current[index + 1].focus();
+    }
+
+    onComplete(newOtp.join(""));
+  };
+
+  const handleKeyDown = (index, e) => {
+    if (e.key === "Backspace" && !otp[index] && index > 0) {
+      inputRefs.current[index - 1].focus();
+    }
+  };
+
+  return (
+    <div style={{ display: "flex", gap: "10px" }}>
+      {otp.map((digit, index) => (
+        <input
+          key={index}
+          type="text"
+          value={digit}
+          onChange={(e) => handleChange(index, e)}
+          onKeyDown={(e) => handleKeyDown(index, e)}
+          maxLength={1}
+          className="border w-[72px] h-[72px] rounded-[2px] border-[#797979] flex text-center justify-center text-2xl font-bold"
+          ref={(el) => (inputRefs.current[index] = el)}
+        />
+      ))}
+    </div>
+  );
+};
+
+export default OtpInput;

--- a/frontend/components/OtpVerification.jsx
+++ b/frontend/components/OtpVerification.jsx
@@ -1,0 +1,46 @@
+"use client";
+import { useEffect, useState } from "react";
+import OtpInput from "./OtpInput";
+
+function OtpVerification() {
+  const [otp, setOtp] = useState("");
+
+  const handleOtpComplete = (otp) => {
+    setOtp(otp);
+  };
+
+  return (
+    <div className="min-h-screen bg-[#ffffff] flex  justify-center p-4 ">
+      <div className="w-full sm:max-w-[480px] p-6 sm:p-8 rounded-lg ">
+        <h2 className="text-3xl sm:text-4xl font-bold text-center mb-3 text-[#29296E]">
+          Check your email
+        </h2>
+        <p className="text-center text-black text-sm sm:text-base mt-8 font-normal">
+          Thanks! If{" "}
+          <span className="text-[#29296a] font-semibold">
+            johnstones@gmail.com
+          </span>{" "}
+          matches an email we have on our record, then we’ve sent you an{" "}
+          <span className="text-[#29296a] font-semibold">OTP</span> to reset
+          your password
+        </p>
+
+        <form className="mt-10">
+          <div className="flex items-center justify-center">
+            <OtpInput length={4} onComplete={handleOtpComplete} />
+          </div>
+
+          <button
+            type="submit"
+            disabled={otp.length !== 4}
+            className="w-full bg-[#29296A] disabled:bg-[#29296A]/40 text-white p-3 rounded-full mt-10 sm:mt-10 text-sm sm:text-base"
+          >
+            Continue
+          </button>
+        </form>
+      </div>
+    </div>
+  );
+}
+
+export default OtpVerification;


### PR DESCRIPTION
**N/B**:  the suggested route "frontend/app/(auth)/forgot-password/page.jsx" was clashing with "frontend/app/(root)/forgot-password/page.jsx"

so i changed mine to "frontend/app/(auth)/forgotPassword/page.jsx"

Fixes: #184 

<img width="1416" alt="Screenshot 2025-02-26 at 9 03 21 PM" src="https://github.com/user-attachments/assets/704d9594-c55c-494e-8d3e-8a34e84688a2" />

