### PR TITLE
fix build error caused by typo

### DIFF
--- a/frontend/app/(root)/dewordle/page.jsx
+++ b/frontend/app/(root)/dewordle/page.jsx
@@ -1,10 +1,10 @@
-import Dewordle from '@/components/Dewordle'
+import Dewordle from '@/components/DeWordle'
 import React from 'react'
 
 const page = () => {
   return (
     <div>
-        <Dewordle/>
+        <Dewordle />
     </div>
   )
 }


### PR DESCRIPTION
# Pull Request

## Description

This PR addresses a build issue caused by a typo error in the import path for the Dewordle component. The incorrect path resulted in a "Module not found" error during deployment. The import path has been corrected to ensure a successful build.

## Related Issue

Closes #319

## Type of Change

<!-- Mark the appropriate option with an "x" (no spaces around the "x") -->

- [x] Bug fix (non-breaking change which fixes an issue)

- [ ] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)Update your CONTRIBUTING.md to reference the template

- [ ] Documentation update

- [ ] Code refactoring

- [ ] Performance improvement

- [ ] Test update

- [ ] Build/CI pipeline change

- [ ] Other (please describe):

## Checklist

<!-- Mark items with an "x" (no spaces around the "x") once completed -->

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document.

- [x] My code follows the code style of this project.

- [x] I have commented my code, particularly in hard-to-understand areas.

- [ ] I have made corresponding changes to the documentation.

- [x] My changes generate no new warnings.

- [ ] I have added tests that prove my fix is effective or that my feature works.

- [x] New and existing unit tests pass locally with my changes.

- [ ] Any dependent changes have been merged and published in downstream modules.

## Screenshots/Recordings

<!-- If applicable, add screenshots or screen recordings to demonstrate the changes -->

## Additional Context

N/A

## Testing Instructions

N/A
