### PR TITLE
removed duplicate sign in paragraph

### DIFF
--- a/frontend/app/(auth)/signup/layout.tsx
+++ b/frontend/app/(auth)/signup/layout.tsx
@@ -28,15 +28,6 @@ const AuthLayout: React.FC<AuthLayoutProps> = ({ children }) => {
             Continue with Apple
           </button>
 
-          <p className="mt-3 text-center text-md text-gray-600">
-            Already have an account?{" "}
-            <Link
-              href="/signin"
-              className="text-[#29296E] hover:border-b-[#29296E] text-md font-[700]"
-            >
-              Log In
-            </Link>
-          </p>
         </div>
       </main>
     </div>

--- a/frontend/components/SignUpForm.jsx
+++ b/frontend/components/SignUpForm.jsx
@@ -309,7 +309,7 @@ const SignUpForm = () => {
                   <p className="text-sm text-gray-600">
                     Already have an account?{" "}
                     <Link
-                      href="/login"
+                      href="/signin"
                       className="text-indigo-600 hover:text-indigo-800"
                     >
                       Sign in


### PR DESCRIPTION
Description:
This update refines the sign-up page by ensuring clarity and eliminating redundancy. The duplicate text "Already have an account? Log In" has been completely removed, leaving only the correct message: "Already have an account? Sign in". Additionally, the "Sign in" link is properly routed to the Sign In page.

Fixes: #334

