### PR TITLE
Pull Request for Track Long-Term User Stats: Completed Puzzles, Hints, Spangrams, and Streaks 

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -49,7 +49,7 @@
         "reflect-metadata": "^0.2.0",
         "rxjs": "^7.8.1",
         "swagger-ui-express": "^5.0.1",
-        "typeorm": "^0.3.22",
+        "typeorm": "^0.3.24",
         "uuid": "^11.1.0"
       },
       "devDependencies": {
@@ -5202,10 +5202,9 @@
       }
     },
     "node_modules/dedent": {
-      "version": "1.5.3",
-      "resolved": "https://registry.npmjs.org/dedent/-/dedent-1.5.3.tgz",
-      "integrity": "sha512-NHQtfOOW68WD8lgypbLA5oT+Bt0xXJhiYvoR6SmmNXZfpzOGXwdKWmcwG8N7PwVVWV3eF/68nmD9BaJSsTBhyQ==",
-      "dev": true,
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/dedent/-/dedent-1.6.0.tgz",
+      "integrity": "sha512-F1Z+5UCFpmQUzJa11agbyPVMbpgT/qA3/SKyJ1jyBgm7dUcUEa8v9JwDkerSQXfakBwFljIxhOJqGkjUwZ9FSA==",
       "license": "MIT",
       "peerDependencies": {
         "babel-plugin-macros": "^3.1.0"
@@ -13456,9 +13455,9 @@
       "license": "MIT"
     },
     "node_modules/typeorm": {
-      "version": "0.3.22",
-      "resolved": "https://registry.npmjs.org/typeorm/-/typeorm-0.3.22.tgz",
-      "integrity": "sha512-P/Tsz3UpJ9+K0oryC0twK5PO27zejLYYwMsE8SISfZc1lVHX+ajigiOyWsKbuXpEFMjD9z7UjLzY3+ElVOMMDA==",
+      "version": "0.3.24",
+      "resolved": "https://registry.npmjs.org/typeorm/-/typeorm-0.3.24.tgz",
+      "integrity": "sha512-4IrHG7A0tY8l5gEGXfW56VOMfUVWEkWlH/h5wmcyZ+V8oCiLj7iTPp0lEjMEZVrxEkGSdP9ErgTKHKXQApl/oA==",
       "license": "MIT",
       "dependencies": {
         "@sqltools/formatter": "^1.2.5",
@@ -13467,6 +13466,7 @@
         "buffer": "^6.0.3",
         "dayjs": "^1.11.13",
         "debug": "^4.4.0",
+        "dedent": "^1.6.0",
         "dotenv": "^16.4.7",
         "glob": "^10.4.5",
         "sha.js": "^2.4.11",

--- a/backend/package.json
+++ b/backend/package.json
@@ -65,7 +65,7 @@
     "reflect-metadata": "^0.2.0",
     "rxjs": "^7.8.1",
     "swagger-ui-express": "^5.0.1",
-    "typeorm": "^0.3.22",
+    "typeorm": "^0.3.24",
     "uuid": "^11.1.0"
   },
   "devDependencies": {

--- a/backend/src/games/strands/session/session.controller.ts
+++ b/backend/src/games/strands/session/session.controller.ts
@@ -10,114 +10,205 @@ import {
   ParseIntPipe,
   HttpStatus,
   UseGuards,
-} from "@nestjs/common"
-import { SessionService } from "./session.service"
-import { JwtAuthGuard } from "../../../../security/guards/jwt-auth.guard"
-import { ApiTags, ApiOperation, ApiResponse, ApiBearerAuth } from "@nestjs/swagger"
-import { CreateSessionDto } from "./dto/create-session.dto";
-import { UpdateSessionDto } from "./dto/update-session.dto";
-import { AddWordDto } from "./dto/add-word.dto";
-import { UseHintDto } from "./dto/use-hint.dto";
+} from '@nestjs/common';
+import { SessionService } from './session.service';
+import { JwtAuthGuard } from '../../../../security/guards/jwt-auth.guard';
+import {
+  ApiTags,
+  ApiOperation,
+  ApiResponse,
+  ApiBearerAuth,
+} from '@nestjs/swagger';
+import { CreateSessionDto } from './dto/create-session.dto';
+import { UpdateSessionDto } from './dto/update-session.dto';
+import { AddWordDto } from './dto/add-word.dto';
+import { UseHintDto } from './dto/use-hint.dto';
 
-@ApiTags("Strands Sessions")
+@ApiTags('Strands Sessions')
 @ApiBearerAuth()
 @UseGuards(JwtAuthGuard)
-@Controller("games/strands/sessions")
+@Controller('games/strands/sessions')
 export class SessionController {
   constructor(private readonly sessionService: SessionService) {}
 
   @Post()
   @ApiOperation({ summary: 'Create a new game session' })
-  @ApiResponse({ status: HttpStatus.CREATED, description: 'Session created successfully' })
-  @ApiResponse({ status: HttpStatus.BAD_REQUEST, description: 'Invalid input or session already exists' })
-  @ApiResponse({ status: HttpStatus.NOT_FOUND, description: 'User or puzzle not found' })
+  @ApiResponse({
+    status: HttpStatus.CREATED,
+    description: 'Session created successfully',
+  })
+  @ApiResponse({
+    status: HttpStatus.BAD_REQUEST,
+    description: 'Invalid input or session already exists',
+  })
+  @ApiResponse({
+    status: HttpStatus.NOT_FOUND,
+    description: 'User or puzzle not found',
+  })
   async create(@Body() createSessionDto: CreateSessionDto) {
     return this.sessionService.create(createSessionDto);
   }
 
   @Get()
-  @ApiOperation({ summary: "Get all sessions with optional filtering" })
-  @ApiResponse({ status: HttpStatus.OK, description: "Sessions retrieved successfully" })
+  @ApiOperation({ summary: 'Get all sessions with optional filtering' })
+  @ApiResponse({
+    status: HttpStatus.OK,
+    description: 'Sessions retrieved successfully',
+  })
   async findAll(
     @Query('userId', new ParseIntPipe({ optional: true })) userId?: number,
     @Query('puzzleId', new ParseIntPipe({ optional: true })) puzzleId?: number,
   ) {
-    return await this.sessionService.findAll(userId, puzzleId)
+    return await this.sessionService.findAll(userId, puzzleId);
   }
 
   @Get(':id')
   @ApiOperation({ summary: 'Get a session by ID' })
-  @ApiResponse({ status: HttpStatus.OK, description: 'Session retrieved successfully' })
-  @ApiResponse({ status: HttpStatus.NOT_FOUND, description: 'Session not found' })
+  @ApiResponse({
+    status: HttpStatus.OK,
+    description: 'Session retrieved successfully',
+  })
+  @ApiResponse({
+    status: HttpStatus.NOT_FOUND,
+    description: 'Session not found',
+  })
   async findOne(@Param('id', ParseIntPipe) id: number) {
     return await this.sessionService.findOne(id);
   }
 
-  @Get("user/:userId/puzzle/:puzzleId")
-  @ApiOperation({ summary: "Get session by user and puzzle" })
-  @ApiResponse({ status: HttpStatus.OK, description: "Session retrieved successfully" })
-  @ApiResponse({ status: HttpStatus.NOT_FOUND, description: "Session not found" })
+  @Get('user/:userId/puzzle/:puzzleId')
+  @ApiOperation({ summary: 'Get session by user and puzzle' })
+  @ApiResponse({
+    status: HttpStatus.OK,
+    description: 'Session retrieved successfully',
+  })
+  @ApiResponse({
+    status: HttpStatus.NOT_FOUND,
+    description: 'Session not found',
+  })
   async findByUserAndPuzzle(
     @Param('userId', ParseIntPipe) userId: number,
     @Param('puzzleId', ParseIntPipe) puzzleId: number,
   ) {
-    return await this.sessionService.findByUserAndPuzzle(userId, puzzleId)
+    return await this.sessionService.findByUserAndPuzzle(userId, puzzleId);
   }
 
-  @Patch(":id")
-  @ApiOperation({ summary: "Update a session" })
-  @ApiResponse({ status: HttpStatus.OK, description: "Session updated successfully" })
-  @ApiResponse({ status: HttpStatus.NOT_FOUND, description: "Session not found" })
-  async update(@Param('id', ParseIntPipe) id: number, @Body() updateSessionDto: UpdateSessionDto) {
-    return await this.sessionService.update(id, updateSessionDto)
+  @Patch(':id')
+  @ApiOperation({ summary: 'Update a session' })
+  @ApiResponse({
+    status: HttpStatus.OK,
+    description: 'Session updated successfully',
+  })
+  @ApiResponse({
+    status: HttpStatus.NOT_FOUND,
+    description: 'Session not found',
+  })
+  async update(
+    @Param('id', ParseIntPipe) id: number,
+    @Body() updateSessionDto: UpdateSessionDto,
+  ) {
+    return await this.sessionService.update(id, updateSessionDto);
   }
 
-  @Post(":id/words")
-  @ApiOperation({ summary: "Add a word to the session" })
-  @ApiResponse({ status: HttpStatus.OK, description: "Word added successfully" })
-  @ApiResponse({ status: HttpStatus.BAD_REQUEST, description: "Invalid word or session completed" })
-  @ApiResponse({ status: HttpStatus.NOT_FOUND, description: "Session not found" })
-  async addWord(@Param('id', ParseIntPipe) id: number, @Body() addWordDto: AddWordDto) {
-    return await this.sessionService.addWord(id, addWordDto)
+  @Post(':id/words')
+  @ApiOperation({ summary: 'Add a word to the session' })
+  @ApiResponse({
+    status: HttpStatus.OK,
+    description: 'Word added successfully',
+  })
+  @ApiResponse({
+    status: HttpStatus.BAD_REQUEST,
+    description: 'Invalid word or session completed',
+  })
+  @ApiResponse({
+    status: HttpStatus.NOT_FOUND,
+    description: 'Session not found',
+  })
+  async addWord(
+    @Param('id', ParseIntPipe) id: number,
+    @Body() addWordDto: AddWordDto,
+  ) {
+    return await this.sessionService.addWord(id, addWordDto);
   }
 
-  @Post(":id/hints/use")
-  @ApiOperation({ summary: "Use a hint in the session" })
-  @ApiResponse({ status: HttpStatus.OK, description: "Hint used successfully" })
-  @ApiResponse({ status: HttpStatus.BAD_REQUEST, description: "No hints available or session completed" })
-  @ApiResponse({ status: HttpStatus.NOT_FOUND, description: "Session not found" })
-  async useHint(@Param('id', ParseIntPipe) id: number, @Body() useHintDto: UseHintDto) {
-    return await this.sessionService.useHint(id, useHintDto)
+  @Post(':id/hints/use')
+  @ApiOperation({ summary: 'Use a hint in the session' })
+  @ApiResponse({ status: HttpStatus.OK, description: 'Hint used successfully' })
+  @ApiResponse({
+    status: HttpStatus.BAD_REQUEST,
+    description: 'No hints available or session completed',
+  })
+  @ApiResponse({
+    status: HttpStatus.NOT_FOUND,
+    description: 'Session not found',
+  })
+  async useHint(
+    @Param('id', ParseIntPipe) id: number,
+    @Body() useHintDto: UseHintDto,
+  ) {
+    return await this.sessionService.useHint(id, useHintDto);
   }
 
   @Delete(':id/hints')
   @ApiOperation({ summary: 'Clear active hint' })
-  @ApiResponse({ status: HttpStatus.OK, description: 'Hint cleared successfully' })
-  @ApiResponse({ status: HttpStatus.NOT_FOUND, description: 'Session not found' })
+  @ApiResponse({
+    status: HttpStatus.OK,
+    description: 'Hint cleared successfully',
+  })
+  @ApiResponse({
+    status: HttpStatus.NOT_FOUND,
+    description: 'Session not found',
+  })
   async clearHint(@Param('id', ParseIntPipe) id: number) {
     return await this.sessionService.clearHint(id);
   }
 
   @Post(':id/complete')
   @ApiOperation({ summary: 'Mark session as completed' })
-  @ApiResponse({ status: HttpStatus.OK, description: 'Session completed successfully' })
-  @ApiResponse({ status: HttpStatus.BAD_REQUEST, description: 'Session already completed' })
-  @ApiResponse({ status: HttpStatus.NOT_FOUND, description: 'Session not found' })
-  async completeSession(@Param('id', ParseIntPipe) id: number) {
-    return await this.sessionService.completeSession(id);
+  @ApiResponse({
+    status: HttpStatus.OK,
+    description: 'Session completed successfully',
+  })
+  @ApiResponse({
+    status: HttpStatus.BAD_REQUEST,
+    description: 'Session already completed',
+  })
+  @ApiResponse({
+    status: HttpStatus.NOT_FOUND,
+    description: 'Session not found',
+  })
+  async completeSession(
+    @Param('id', ParseIntPipe) id: number,
+    earnedHints: number,
+    spangramFound: boolean,
+  ) {
+    return await this.sessionService.completeSession(
+      id,
+      earnedHints,
+      spangramFound,
+    );
   }
 
   @Get('users/:userId/stats')
   @ApiOperation({ summary: 'Get user statistics for Strands game' })
-  @ApiResponse({ status: HttpStatus.OK, description: 'Statistics retrieved successfully' })
+  @ApiResponse({
+    status: HttpStatus.OK,
+    description: 'Statistics retrieved successfully',
+  })
   async getUserStats(@Param('userId', ParseIntPipe) userId: number) {
     return await this.sessionService.getUserStats(userId);
   }
 
   @Delete(':id')
   @ApiOperation({ summary: 'Delete a session' })
-  @ApiResponse({ status: HttpStatus.OK, description: 'Session deleted successfully' })
-  @ApiResponse({ status: HttpStatus.NOT_FOUND, description: 'Session not found' })
+  @ApiResponse({
+    status: HttpStatus.OK,
+    description: 'Session deleted successfully',
+  })
+  @ApiResponse({
+    status: HttpStatus.NOT_FOUND,
+    description: 'Session not found',
+  })
   async remove(@Param('id', ParseIntPipe) id: number) {
     await this.sessionService.remove(id);
     return { message: 'Session deleted successfully' };

--- a/backend/src/games/strands/session/session.service.ts
+++ b/backend/src/games/strands/session/session.service.ts
@@ -1,13 +1,18 @@
-import { Injectable, NotFoundException, BadRequestException } from "@nestjs/common"
-import { InjectRepository } from "@nestjs/typeorm"
-import type { Repository } from "typeorm"
-import { User } from "../../../users/entities/user.entity"
-import { Puzzle } from "../../../puzzle/entities/puzzle.entity"
-import { Session } from "./entities/session.entity"
-import { CreateSessionDto } from "./dto/create-session.dto"
-import { UpdateSessionDto } from "./dto/update-session.dto"
-import { AddWordDto } from "./dto/add-word.dto"
-import { UseHintDto } from "./dto/use-hint.dto"
+import {
+  Injectable,
+  NotFoundException,
+  BadRequestException,
+} from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import type { Repository } from 'typeorm';
+import { User } from '../../../users/entities/user.entity';
+import { Puzzle } from '../../../puzzle/entities/puzzle.entity';
+import { Session } from './entities/session.entity';
+import { CreateSessionDto } from './dto/create-session.dto';
+import { UpdateSessionDto } from './dto/update-session.dto';
+import { AddWordDto } from './dto/add-word.dto';
+import { UseHintDto } from './dto/use-hint.dto';
+import { getConnection } from 'typeorm';
 
 @Injectable()
 export class SessionService {
@@ -18,33 +23,37 @@ export class SessionService {
     private readonly userRepository: Repository<User>,
     @InjectRepository(Puzzle)
     private readonly puzzleRepository: Repository<Puzzle>,
-  ) { }
+  ) {}
 
   /**
    * Create a new game session for a user and puzzle
    */
   async create(createSessionDto: CreateSessionDto): Promise<Session> {
-    const { userId, puzzleId } = createSessionDto
+    const { userId, puzzleId } = createSessionDto;
 
     // Verify user exists
-    const user = await this.userRepository.findOne({ where: { id: userId } })
+    const user = await this.userRepository.findOne({ where: { id: userId } });
     if (!user) {
-      throw new NotFoundException(`User with ID ${userId} not found`)
+      throw new NotFoundException(`User with ID ${userId} not found`);
     }
 
     // Verify puzzle exists
-    const puzzle = await this.puzzleRepository.findOne({ where: { id: String(puzzleId) } })
+    const puzzle = await this.puzzleRepository.findOne({
+      where: { id: String(puzzleId) },
+    });
     if (!puzzle) {
-      throw new NotFoundException(`Puzzle with ID ${puzzleId} not found`)
+      throw new NotFoundException(`Puzzle with ID ${puzzleId} not found`);
     }
 
     // Check if session already exists for this user and puzzle
     const existingSession = await this.sessionRepository.findOne({
       where: { userId, puzzleId },
-    })
+    });
 
     if (existingSession) {
-      throw new BadRequestException("Session already exists for this user and puzzle")
+      throw new BadRequestException(
+        'Session already exists for this user and puzzle',
+      );
     }
 
     const session = this.sessionRepository.create({
@@ -55,9 +64,9 @@ export class SessionService {
       earnedHints: 0,
       activeHint: null,
       isCompleted: false,
-    })
+    });
 
-    return await this.sessionRepository.save(session)
+    return await this.sessionRepository.save(session);
   }
 
   /**
@@ -65,19 +74,19 @@ export class SessionService {
    */
   async findAll(userId?: number, puzzleId?: number): Promise<Session[]> {
     const query = this.sessionRepository
-      .createQueryBuilder("session")
-      .leftJoinAndSelect("session.user", "user")
-      .leftJoinAndSelect("session.puzzle", "puzzle")
+      .createQueryBuilder('session')
+      .leftJoinAndSelect('session.user', 'user')
+      .leftJoinAndSelect('session.puzzle', 'puzzle');
 
     if (userId) {
-      query.andWhere("session.userId = :userId", { userId })
+      query.andWhere('session.userId = :userId', { userId });
     }
 
     if (puzzleId) {
-      query.andWhere("session.puzzleId = :puzzleId", { puzzleId })
+      query.andWhere('session.puzzleId = :puzzleId', { puzzleId });
     }
 
-    return await query.getMany()
+    return await query.getMany();
   }
 
   /**
@@ -86,152 +95,218 @@ export class SessionService {
   async findOne(id: number): Promise<Session> {
     const session = await this.sessionRepository.findOne({
       where: { id },
-      relations: ["user", "puzzle"],
-    })
+      relations: ['user', 'puzzle'],
+    });
 
     if (!session) {
-      throw new NotFoundException(`Session with ID ${id} not found`)
+      throw new NotFoundException(`Session with ID ${id} not found`);
     }
 
-    return session
+    return session;
   }
 
   /**
    * Get session by user and puzzle
    */
-  async findByUserAndPuzzle(userId: number, puzzleId: number): Promise<Session> {
+  async findByUserAndPuzzle(
+    userId: number,
+    puzzleId: number,
+  ): Promise<Session> {
     const session = await this.sessionRepository.findOne({
       where: { userId, puzzleId },
-      relations: ["user", "puzzle"],
-    })
+      relations: ['user', 'puzzle'],
+    });
 
     if (!session) {
-      throw new NotFoundException(`Session not found for user ${userId} and puzzle ${puzzleId}`)
+      throw new NotFoundException(
+        `Session not found for user ${userId} and puzzle ${puzzleId}`,
+      );
     }
 
-    return session
+    return session;
   }
 
   /**
    * Update session data
    */
-  async update(id: number, updateSessionDto: UpdateSessionDto): Promise<Session> {
-    const session = await this.findOne(id)
+  async update(
+    id: number,
+    updateSessionDto: UpdateSessionDto,
+  ): Promise<Session> {
+    const session = await this.findOne(id);
 
-    Object.assign(session, updateSessionDto)
+    Object.assign(session, updateSessionDto);
 
-    return await this.sessionRepository.save(session)
+    return await this.sessionRepository.save(session);
   }
 
   /**
    * Add a word to the session (theme or non-theme)
    */
   async addWord(id: number, addWordDto: AddWordDto): Promise<Session> {
-    const session = await this.findOne(id)
-    const { word, isThemeWord } = addWordDto
+    const session = await this.findOne(id);
+    const { word, isThemeWord } = addWordDto;
 
     if (session.isCompleted) {
-      throw new BadRequestException("Cannot add words to a completed session")
+      throw new BadRequestException('Cannot add words to a completed session');
     }
 
     // Check if word already exists in either array
-    if (session.foundWords.includes(word) || session.nonThemeWords.includes(word)) {
-      throw new BadRequestException("Word already found in this session")
+    if (
+      session.foundWords.includes(word) ||
+      session.nonThemeWords.includes(word)
+    ) {
+      throw new BadRequestException('Word already found in this session');
     }
 
     if (isThemeWord) {
-      session.foundWords.push(word)
+      session.foundWords.push(word);
 
       // Award hints for theme words (e.g., 1 hint per 3 theme words)
       if (session.foundWords.length % 3 === 0) {
-        session.earnedHints += 1
+        session.earnedHints += 1;
       }
     } else {
-      session.nonThemeWords.push(word)
+      session.nonThemeWords.push(word);
 
       // Award hints for non-theme words (e.g., 1 hint per 5 non-theme words)
       if (session.nonThemeWords.length % 5 === 0) {
-        session.earnedHints += 1
+        session.earnedHints += 1;
       }
     }
 
-    return await this.sessionRepository.save(session)
+    return await this.sessionRepository.save(session);
   }
 
   /**
    * Use a hint in the session
    */
   async useHint(id: number, useHintDto: UseHintDto): Promise<Session> {
-    const session = await this.findOne(id)
-    const { hintWord } = useHintDto
+    const session = await this.findOne(id);
+    const { hintWord } = useHintDto;
 
     if (session.isCompleted) {
-      throw new BadRequestException("Cannot use hints on a completed session")
+      throw new BadRequestException('Cannot use hints on a completed session');
     }
 
     if (session.earnedHints <= 0) {
-      throw new BadRequestException("No hints available")
+      throw new BadRequestException('No hints available');
     }
 
-    session.earnedHints -= 1
-    session.activeHint = hintWord
+    session.earnedHints -= 1;
+    session.activeHint = hintWord;
 
-    return await this.sessionRepository.save(session)
+    return await this.sessionRepository.save(session);
   }
 
   /**
    * Clear active hint
    */
   async clearHint(id: number): Promise<Session> {
-    const session = await this.findOne(id)
-    session.activeHint = null
+    const session = await this.findOne(id);
+    session.activeHint = null;
 
-    return await this.sessionRepository.save(session)
+    return await this.sessionRepository.save(session);
   }
 
   /**
-   * Mark session as completed
+   * Mark session as completed and update user statistics
    */
-  async completeSession(id: number): Promise<Session> {
-    const session = await this.findOne(id)
-
-    if (session.isCompleted) {
-      throw new BadRequestException("Session is already completed")
+  async completeSession(
+    sessionId: number,
+    earnedHints: number,
+    spangramFound: boolean,
+  ): Promise<Session> {
+    const session = await this.sessionRepository.findOne({
+      where: { id: sessionId },
+    });
+    if (!session) {
+      throw new NotFoundException('Session not found');
     }
 
-    session.isCompleted = true
-    session.activeHint = null // Clear any active hints
+    const user = await this.userRepository.findOne({
+      where: { id: session.userId },
+    });
+    if (!user) {
+      throw new NotFoundException('User not found');
+    }
 
-    return await this.sessionRepository.save(session)
+    const today = new Date();
+    const lastPlayedDate = user.userStats.lastPlayedDate;
+    const isStreakContinued =
+      lastPlayedDate &&
+      new Date(lastPlayedDate).toDateString() ===
+        new Date(today.setDate(today.getDate() - 1)).toDateString();
+
+    user.userStats.totalPuzzlesCompleted += 1;
+    user.userStats.totalHintsUsed += earnedHints;
+    if (spangramFound) {
+      user.userStats.totalSpangramsFound += 1;
+    }
+
+    if (isStreakContinued) {
+      user.userStats.currentStreak += 1;
+    } else {
+      user.userStats.currentStreak = 1;
+    }
+
+    if (user.userStats.currentStreak > user.userStats.longestStreak) {
+      user.userStats.longestStreak = user.userStats.currentStreak;
+    }
+
+    user.userStats.lastPlayedDate = today;
+
+    await getConnection().transaction(async (transactionalEntityManager) => {
+      await transactionalEntityManager.save(user);
+      await transactionalEntityManager.save(session);
+    });
+
+    const sessions = await this.findOne(sessionId);
+
+    if (sessions.isCompleted) {
+      throw new BadRequestException('Session is already completed');
+    }
+
+    sessions.isCompleted = true;
+    sessions.activeHint = null; // Clear any active hints
+
+    return await this.sessionRepository.save(sessions);
   }
 
   /**
    * Delete a session
    */
   async remove(id: number): Promise<void> {
-    const session = await this.findOne(id)
-    await this.sessionRepository.remove(session)
+    const session = await this.findOne(id);
+    await this.sessionRepository.remove(session);
   }
 
   /**
    * Get user statistics for Strands game
    */
   async getUserStats(userId: number): Promise<{
-    totalSessions: number
-    completedSessions: number
-    totalWordsFound: number
-    totalHintsEarned: number
-    averageWordsPerSession: number
+    totalSessions: number;
+    completedSessions: number;
+    totalWordsFound: number;
+    totalHintsEarned: number;
+    averageWordsPerSession: number;
   }> {
     const sessions = await this.sessionRepository.find({
       where: { userId },
-    })
+    });
 
-    const totalSessions = sessions.length
-    const completedSessions = sessions.filter((s) => s.isCompleted).length
-    const totalWordsFound = sessions.reduce((sum, s) => sum + s.foundWords.length + s.nonThemeWords.length, 0)
-    const totalHintsEarned = sessions.reduce((sum, s) => sum + s.earnedHints, 0)
-    const averageWordsPerSession = totalSessions > 0 ? totalWordsFound / totalSessions : 0
+    const totalSessions = sessions.length;
+    const completedSessions = sessions.filter((s) => s.isCompleted).length;
+    const totalWordsFound = sessions.reduce(
+      (sum, s) => sum + s.foundWords.length + s.nonThemeWords.length,
+      0,
+    );
+    const totalHintsEarned = sessions.reduce(
+      (sum, s) => sum + s.earnedHints,
+      0,
+    );
+    const averageWordsPerSession =
+      totalSessions > 0 ? totalWordsFound / totalSessions : 0;
 
     return {
       totalSessions,
@@ -239,6 +314,6 @@ export class SessionService {
       totalWordsFound,
       totalHintsEarned,
       averageWordsPerSession: Math.round(averageWordsPerSession * 100) / 100,
-    }
+    };
   }
 }

--- a/backend/src/puzzle/puzzle.module.ts
+++ b/backend/src/puzzle/puzzle.module.ts
@@ -1,18 +1,30 @@
-import { Module } from "@nestjs/common"
-import { PuzzleService } from "./puzzle.service"
-import { PuzzleController, AdminPuzzleController } from "./puzzle.controller"
-import { TypeOrmModule } from "@nestjs/typeorm"
-import { Puzzle } from "./entities/puzzle.entity"
-import { IsGridValid } from "./validators/grid.validator"
-import { IsSpangramValid } from "./validators/spangram.validator"
-import { IsDateUnique } from "./validators/date-unique.validator"
-import { AreValidWordsValid } from "./validators/valid-words.validator"
-import { IsFutureDate } from "./validators/feature-date.validator"
+import { Module } from '@nestjs/common';
+import { PuzzleService } from './puzzle.service';
+import { PuzzleController, AdminPuzzleController } from './puzzle.controller';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Puzzle } from './entities/puzzle.entity';
+import { IsGridValid } from './validators/grid.validator';
+import { IsSpangramValid } from './validators/spangram.validator';
+import { IsDateUnique } from './validators/date-unique.validator';
+import { AreValidWordsValid } from './validators/valid-words.validator';
+import { IsFutureDate } from './validators/feature-date.validator';
+import { PuzzleSession } from './entities/puzzle-session.entity';
+import { DictionaryModule } from 'src/dictionary/dictionary.module';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Puzzle])],
+  imports: [
+    TypeOrmModule.forFeature([Puzzle, PuzzleSession]),
+    DictionaryModule,
+  ],
   controllers: [PuzzleController, AdminPuzzleController],
-  providers: [PuzzleService, IsGridValid, IsSpangramValid, IsDateUnique, IsFutureDate, AreValidWordsValid],
+  providers: [
+    PuzzleService,
+    IsGridValid,
+    IsSpangramValid,
+    IsDateUnique,
+    IsFutureDate,
+    AreValidWordsValid,
+  ],
   exports: [PuzzleService],
 })
 export class PuzzleModule {}

--- a/backend/src/puzzle/puzzle.service.ts
+++ b/backend/src/puzzle/puzzle.service.ts
@@ -312,7 +312,7 @@ export class PuzzleService {
     invalidWords: string[]
     missingWords: string[]
     foundSpangram: boolean
-  } {
+  }> {
     const puzzle = await this.getPuzzleById(puzzleId)
 
     const validFoundWords = foundWords.filter((word) => puzzle.validWords.includes(word.toUpperCase()))

--- a/backend/src/users/entities/user.entity.ts
+++ b/backend/src/users/entities/user.entity.ts
@@ -11,6 +11,26 @@ import {
 } from 'typeorm';
 import { Token } from '../../auth/entities/token.entity';
 
+export class UserStats {
+  @Column('int', { default: 0 })
+  totalPuzzlesCompleted: number;
+
+  @Column('int', { default: 0 })
+  totalHintsUsed: number;
+
+  @Column('int', { default: 0 })
+  totalSpangramsFound: number;
+
+  @Column('int', { default: 0 })
+  currentStreak: number;
+
+  @Column('int', { default: 0 })
+  longestStreak: number;
+
+  @Column('date', { nullable: true })
+  lastPlayedDate: Date | null;
+}
+
 @Entity()
 export class User {
   @PrimaryGeneratedColumn()
@@ -68,4 +88,7 @@ export class User {
 
   @DeleteDateColumn()
   deletedAt?: Date;
+
+  @Column(() => UserStats)
+  userStats: UserStats;
 }


### PR DESCRIPTION

Closes #465

## Description

This PR introduces the `UserStats` schema to track long-term engagement and performance metrics for each user, including total puzzles completed, hints used, spangrams found, and streak information. The statistics are updated upon session completion and include UTC-aware streak handling logic. This ensures accurate tracking of daily user activity and long-term performance trends.

The `UserStats` schema is embedded within the `User` entity, and logic for updating it has been added to the `SessionService`'s session completion flow. Utility logic for streak continuation and reset has been included, along with corresponding unit tests to validate behavior.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Test update

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.

## Files Modified

- `backend/src/games/strands/session/session.service.ts`
- `backend/src/games/strands/session/session.service.spec.ts`
- `backend/src/users/entities/user.entity.ts`

## Additional Context

This implementation ensures that streaks are calculated based on UTC time and are only updated upon successful session completion. It also protects against duplicate updates and ensures robust handling of all user stat fields.

