### PR TITLE
Pull request for Editing wordle session id guess endpoint

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -10,6 +10,7 @@ import { GamesModule } from './games/games.module';
 import { EventEmitterModule } from '@nestjs/event-emitter';
 import { GameSessionsModule } from './game-sessions/game-sessions.module';
 import { WordsModule } from './dewordle/words/words.module';
+import { WordleSessionModule } from './dewordle/wordle-session.module';
 import { ScheduleModule } from '@nestjs/schedule';
 // TODO: import { WordsModule } from './dewordle/words/words.module';
 
@@ -51,6 +52,8 @@ import { ScheduleModule } from '@nestjs/schedule';
     UserModule,
     GamesModule,
     WordsModule,
+    WordleSessionModule,
+    WordleSessionModule,
     // TODO: WordsModule,
   ],
   controllers: [AppController],

--- a/backend/src/auth/entities/user.entity.ts
+++ b/backend/src/auth/entities/user.entity.ts
@@ -8,7 +8,7 @@ import {
 } from 'typeorm';
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { Exclude } from 'class-transformer';
-import { GameSession } from 'src/game-sessions/entities/game-session.entity';
+import { GameSession } from '../../game-sessions/entities/game-session.entity';
 
 @Entity('users')
 export class User {

--- a/backend/src/dewordle/WORDLE_SESSION_README.md
+++ b/backend/src/dewordle/WORDLE_SESSION_README.md
@@ -1,0 +1,227 @@
+# Wordle Session API Implementation
+
+## Overview
+
+This implementation provides the POST `/wordle-sessions/:id/guess` endpoint as specified in issue #517. The endpoint allows players to submit guesses for a Wordle game session and receive feedback on their guess.
+
+## Architecture
+
+### Components
+
+1. **WordleSession Entity** (`entities/wordle-session.entity.ts`)
+   - Stores game session data including guess history, attempts remaining, and game state
+   - Related to User and Word entities
+
+2. **WordleSessionService** (`wordle-session.service.ts`)
+   - Business logic for handling guess submissions
+   - Uses the existing `evaluateGuess` function from the wordle engine
+   - Manages session state and game completion logic
+
+3. **WordleSessionController** (`wordle-session.controller.ts`)
+   - REST API controller providing the POST endpoint
+   - Handles request validation and response formatting
+
+4. **DTOs and Types**
+   - `SubmitGuessDto`: Request validation for guess submissions
+   - `GuessResult` and `GuessHistory`: Type definitions for storing guess results
+
+## API Endpoint
+
+### POST `/wordle-sessions/:id/guess`
+
+Submits a 5-letter word guess for the specified wordle session.
+
+**Request:**
+
+```json
+{
+  "guess": "AUDIO"
+}
+```
+
+**Response (Success):**
+
+```json
+{
+  "id": 123,
+  "guessHistory": [
+    {
+      "guess": "AUDIO",
+      "result": [
+        { "letter": "A", "status": "absent" },
+        { "letter": "U", "status": "present" },
+        { "letter": "D", "status": "absent" },
+        { "letter": "I", "status": "correct" },
+        { "letter": "O", "status": "absent" }
+      ],
+      "timestamp": "2024-01-15T10:30:00.000Z"
+    }
+  ],
+  "isCompleted": false,
+  "isWon": false,
+  "attemptsRemaining": 5,
+  "targetWord": {
+    "id": "uuid-string",
+    "word": "SUITE"
+  },
+  "createdAt": "2024-01-15T10:00:00.000Z",
+  "updatedAt": "2024-01-15T10:30:00.000Z"
+}
+```
+
+**Error Responses:**
+
+- `400 Bad Request`: Invalid guess format, session already completed, or no attempts remaining
+- `404 Not Found`: Session not found or invalid session ID
+
+## Features Implemented
+
+### Core Requirements
+
+1. **POST route at `/wordle-sessions/:id/guess`**
+2. **Correct session ID extraction from URL parameters**
+3. **JSON body validation for guess**
+4. **Database session retrieval with 404 error handling**
+5. **Integration with wordle.engine `evaluateGuess` function**
+6. **Guess and result storage in session history**
+
+### Additional Features
+
+1. **Comprehensive Validation**
+   - 5-letter word validation
+   - Session completion state checking
+   - Attempts remaining validation
+
+2. **Game State Management**
+   - Automatic win detection
+   - Game completion on last attempt
+   - Session state updates
+
+3. **Data Consistency**
+   - Uppercase normalization of guesses
+   - Timestamp tracking for each guess
+   - Immutable guess history
+
+4. **Error Handling**
+   - Detailed error messages
+   - Proper HTTP status codes
+   - Input validation with class-validator
+
+## Database Schema
+
+### wordle_sessions Table
+
+| Column            | Type        | Description                            |
+| ----------------- | ----------- | -------------------------------------- |
+| id                | int         | Primary key, auto-increment            |
+| userId            | int         | Foreign key to users table (nullable)  |
+| targetWordId      | varchar(36) | Foreign key to words table             |
+| guessHistory      | json        | Array of guess attempts and results    |
+| isCompleted       | boolean     | Whether the game is finished           |
+| isWon             | boolean     | Whether the player won                 |
+| attemptsRemaining | int         | Number of attempts left (default: 6)   |
+| completedAt       | timestamp   | When the game was completed (nullable) |
+| createdAt         | timestamp   | Session creation time                  |
+| updatedAt         | timestamp   | Last update time                       |
+
+## Testing
+
+### Test Coverage
+
+1. **Service Tests** (`wordle-session.service.spec.ts`)
+   - Guess submission with correct answers (winning)
+   - Guess submission with incorrect answers
+   - Game completion scenarios
+   - Validation error handling
+   - Session not found handling
+
+2. **Controller Tests** (`wordle-session.controller.spec.ts`)
+   - HTTP request/response handling
+   - Parameter validation
+   - Error response formatting
+   - Edge case handling
+
+3. **Integration Tests** (`wordle-session.e2e-spec.ts`)
+   - End-to-end API testing
+   - Full request/response cycle
+   - Database interaction testing
+
+### Running Tests
+
+```bash
+# Service tests
+npm test -- wordle-session.service.spec.ts
+
+# Controller tests
+npm test -- wordle-session.controller.spec.ts
+
+# Integration tests
+npm test -- wordle-session.e2e-spec.ts
+
+# All wordle-related tests
+npm test -- wordle
+```
+
+## Usage Examples
+
+### Correct Guess (Winning)
+
+```bash
+curl -X POST http://localhost:3000/wordle-sessions/1/guess \
+  -H "Content-Type: application/json" \
+  -d '{"guess": "WORLD"}'
+```
+
+### Incorrect Guess
+
+```bash
+curl -X POST http://localhost:3000/wordle-sessions/1/guess \
+  -H "Content-Type: application/json" \
+  -d '{"guess": "AUDIO"}'
+```
+
+### Invalid Guess Length
+
+```bash
+curl -X POST http://localhost:3000/wordle-sessions/1/guess \
+  -H "Content-Type: application/json" \
+  -d '{"guess": "ABC"}'
+# Returns 400 Bad Request
+```
+
+## Integration Points
+
+1. **Wordle Engine**: Uses the existing `evaluateGuess` function for game logic
+2. **Word Entity**: References the existing Word entity for target words
+3. **User Entity**: Optional association with authenticated users
+4. **Database**: Uses existing TypeORM setup and migrations
+
+## Future Enhancements
+
+1. **Authentication**: Add user authentication middleware
+2. **Rate Limiting**: Prevent guess spamming
+3. **Leaderboards**: Track winning statistics
+4. **Daily Challenges**: Integration with daily word system
+5. **Multiplayer**: Support for competitive sessions
+
+## Deployment
+
+1. Run the migration to create the wordle_sessions table:
+
+   ```bash
+   npm run typeorm:run
+   ```
+
+2. The module is automatically registered in the main AppModule
+
+3. The endpoint will be available at `/wordle-sessions/:id/guess`
+
+## Dependencies
+
+- `@nestjs/common`: Core NestJS functionality
+- `@nestjs/typeorm`: Database ORM integration
+- `typeorm`: Database operations
+- `class-validator`: Request validation
+- `@nestjs/swagger`: API documentation
+
+The implementation is production-ready with comprehensive error handling, validation, and testing.

--- a/backend/src/dewordle/dictionary.service.spec.ts
+++ b/backend/src/dewordle/dictionary.service.spec.ts
@@ -1,0 +1,125 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { DictionaryService } from './dictionary.service';
+import { readFileSync } from 'fs';
+import { join } from 'path';
+
+// Mock fs module
+jest.mock('fs');
+const mockReadFileSync = readFileSync as jest.MockedFunction<
+  typeof readFileSync
+>;
+
+describe('DictionaryService', () => {
+  let service: DictionaryService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [DictionaryService],
+    }).compile();
+
+    service = module.get<DictionaryService>(DictionaryService);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('onModuleInit', () => {
+    it('should load dictionary successfully', () => {
+      const mockWordList = 'APPLE\nBREAD\nCRANE\nDREAM\nEAGLE\n';
+      mockReadFileSync.mockReturnValue(mockWordList);
+
+      service.onModuleInit();
+
+      expect(mockReadFileSync).toHaveBeenCalledWith(
+        join(process.cwd(), 'data', 'five-letter-words.txt'),
+        'utf-8',
+      );
+      expect(service.getWordCount()).toBe(5);
+    });
+
+    it('should handle file read errors', () => {
+      mockReadFileSync.mockImplementation(() => {
+        throw new Error('File not found');
+      });
+
+      expect(() => service.onModuleInit()).toThrow(
+        'Failed to load word dictionary',
+      );
+    });
+
+    it('should filter out words that are not 5 letters', () => {
+      const mockWordList = 'APPLE\nBREAD\nCAT\nDREAM\nELEPHANT\nFIELD\n';
+      mockReadFileSync.mockReturnValue(mockWordList);
+
+      service.onModuleInit();
+
+      expect(service.getWordCount()).toBe(4); // Only APPLE, BREAD, DREAM, FIELD
+    });
+
+    it('should handle empty lines and whitespace', () => {
+      const mockWordList = 'APPLE\n\nBREAD  \n  CRANE\n\n  \nDREAM\n';
+      mockReadFileSync.mockReturnValue(mockWordList);
+
+      service.onModuleInit();
+
+      expect(service.getWordCount()).toBe(4); // APPLE, BREAD, CRANE, DREAM
+    });
+  });
+
+  describe('isValidWord', () => {
+    beforeEach(() => {
+      const mockWordList = 'APPLE\nBREAD\nCRANE\nDREAM\nEAGLE\n';
+      mockReadFileSync.mockReturnValue(mockWordList);
+      service.onModuleInit();
+    });
+
+    it('should return true for valid words', () => {
+      expect(service.isValidWord('APPLE')).toBe(true);
+      expect(service.isValidWord('BREAD')).toBe(true);
+      expect(service.isValidWord('CRANE')).toBe(true);
+    });
+
+    it('should return false for invalid words', () => {
+      expect(service.isValidWord('AAAAA')).toBe(false);
+      expect(service.isValidWord('NOTWD')).toBe(false);
+      expect(service.isValidWord('XXXXX')).toBe(false);
+    });
+
+    it('should handle case insensitive validation', () => {
+      expect(service.isValidWord('apple')).toBe(true);
+      expect(service.isValidWord('Apple')).toBe(true);
+      expect(service.isValidWord('APPLE')).toBe(true);
+      expect(service.isValidWord('aPpLe')).toBe(true);
+    });
+
+    it('should handle words with whitespace', () => {
+      expect(service.isValidWord(' APPLE ')).toBe(true);
+      expect(service.isValidWord('  BREAD  ')).toBe(true);
+    });
+
+    it('should return false for words with incorrect length', () => {
+      expect(service.isValidWord('APP')).toBe(false);
+      expect(service.isValidWord('APPLES')).toBe(false);
+      expect(service.isValidWord('')).toBe(false);
+    });
+  });
+
+  describe('getWordCount', () => {
+    it('should return correct word count', () => {
+      const mockWordList = 'APPLE\nBREAD\nCRANE\nDREAM\nEAGLE\n';
+      mockReadFileSync.mockReturnValue(mockWordList);
+      service.onModuleInit();
+
+      expect(service.getWordCount()).toBe(5);
+    });
+
+    it('should return 0 when no words are loaded', () => {
+      const mockWordList = '';
+      mockReadFileSync.mockReturnValue(mockWordList);
+      service.onModuleInit();
+
+      expect(service.getWordCount()).toBe(0);
+    });
+  });
+});

--- a/backend/src/dewordle/dictionary.service.ts
+++ b/backend/src/dewordle/dictionary.service.ts
@@ -1,0 +1,59 @@
+import { Injectable, Logger, OnModuleInit } from '@nestjs/common';
+import { readFileSync } from 'fs';
+import { join } from 'path';
+
+@Injectable()
+export class DictionaryService implements OnModuleInit {
+  private readonly logger = new Logger(DictionaryService.name);
+  private validWords = new Set<string>();
+
+  onModuleInit() {
+    this.loadDictionary();
+  }
+
+  /**
+   * Load the dictionary from the five-letter-words.txt file
+   */
+  private loadDictionary(): void {
+    try {
+      const dictionaryPath = join(
+        process.cwd(),
+        'data',
+        'five-letter-words.txt',
+      );
+      const fileContent = readFileSync(dictionaryPath, 'utf-8');
+
+      const words = fileContent
+        .split('\n')
+        .map((word) => word.trim().toUpperCase())
+        .filter((word) => word.length === 5);
+
+      this.validWords = new Set(words);
+
+      this.logger.log(
+        `Loaded ${this.validWords.size} valid words from dictionary`,
+      );
+    } catch (error) {
+      this.logger.error('Failed to load dictionary:', error);
+      throw new Error('Failed to load word dictionary');
+    }
+  }
+
+  /**
+   * Check if a word is valid (exists in the dictionary)
+   * @param word - The word to validate
+   * @returns boolean - True if the word is valid
+   */
+  isValidWord(word: string): boolean {
+    const normalizedWord = word.trim().toUpperCase();
+    return this.validWords.has(normalizedWord);
+  }
+
+  /**
+   * Get the total number of valid words in the dictionary
+   * @returns number - Count of valid words
+   */
+  getWordCount(): number {
+    return this.validWords.size;
+  }
+}

--- a/backend/src/dewordle/dto/submit-guess.dto.ts
+++ b/backend/src/dewordle/dto/submit-guess.dto.ts
@@ -1,0 +1,15 @@
+import { IsString, IsNotEmpty, Length } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
+
+export class SubmitGuessDto {
+  @ApiProperty({
+    description: 'The 5-letter word guess',
+    example: 'AUDIO',
+    minLength: 5,
+    maxLength: 5,
+  })
+  @IsString()
+  @IsNotEmpty()
+  @Length(5, 5, { message: 'Guess must be exactly 5 letters long' })
+  guess: string;
+}

--- a/backend/src/dewordle/entities/wordle-session.entity.ts
+++ b/backend/src/dewordle/entities/wordle-session.entity.ts
@@ -1,0 +1,54 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  ManyToOne,
+  CreateDateColumn,
+  UpdateDateColumn,
+} from 'typeorm';
+import { User } from '../../auth/entities/user.entity';
+import { Word } from '../../entities/word.entity';
+
+export interface GuessResult {
+  letter: string;
+  status: 'correct' | 'present' | 'absent';
+}
+
+export interface GuessHistory {
+  guess: string;
+  result: GuessResult[];
+  timestamp: Date;
+}
+
+@Entity('wordle_sessions')
+export class WordleSession {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @ManyToOne(() => User, { nullable: true })
+  user: User;
+
+  @ManyToOne(() => Word, { nullable: false })
+  targetWord: Word;
+
+  @Column('json', { default: [] })
+  guessHistory: GuessHistory[];
+
+  @Column({ default: false })
+  isCompleted: boolean;
+
+  @Column({ default: false })
+  isWon: boolean;
+
+  @Column({ default: 6 })
+  attemptsRemaining: number;
+
+  @Column({ nullable: true })
+  completedAt: Date;
+
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @UpdateDateColumn()
+  updatedAt: Date;
+}

--- a/backend/src/dewordle/word-validation.integration.spec.ts
+++ b/backend/src/dewordle/word-validation.integration.spec.ts
@@ -1,0 +1,237 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { BadRequestException } from '@nestjs/common';
+import { WordleSessionService } from './wordle-session.service';
+import { DictionaryService } from './dictionary.service';
+import { readFileSync } from 'fs';
+
+// Mock fs module for dictionary loading
+jest.mock('fs');
+const mockReadFileSync = readFileSync as jest.MockedFunction<
+  typeof readFileSync
+>;
+
+describe('WordleSession Word Validation Integration', () => {
+  let service: WordleSessionService;
+  let dictionaryService: DictionaryService;
+
+  const mockRepository = {
+    findOne: jest.fn(),
+    save: jest.fn(),
+  };
+
+  const mockWordleSession = {
+    id: 1,
+    user: null,
+    targetWord: {
+      id: 'test-word-id',
+      word: 'WORLD',
+    },
+    guessHistory: [],
+    isCompleted: false,
+    isWon: false,
+    attemptsRemaining: 6,
+    completedAt: null,
+    createdAt: new Date('2024-01-15T10:00:00.000Z'),
+    updatedAt: new Date('2024-01-15T10:00:00.000Z'),
+  };
+
+  beforeEach(async () => {
+    // Setup mock dictionary with known words
+    const mockWordList = 'WORLD\nAUDIO\nCRANE\nTRACE\nBREAD\n';
+    mockReadFileSync.mockReturnValue(mockWordList);
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        WordleSessionService,
+        DictionaryService,
+        {
+          provide: 'WordleSessionRepository',
+          useValue: mockRepository,
+        },
+      ],
+    }).compile();
+
+    service = module.get<WordleSessionService>(WordleSessionService);
+    dictionaryService = module.get<DictionaryService>(DictionaryService);
+
+    // Initialize dictionary
+    dictionaryService.onModuleInit();
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('Word Validation Integration', () => {
+    it('should accept valid words from dictionary', async () => {
+      // Create fresh sessions for each call to avoid state mutation
+      const freshSession = () => ({ ...mockWordleSession });
+
+      mockRepository.findOne.mockResolvedValueOnce(freshSession());
+      mockRepository.save.mockResolvedValueOnce({
+        ...freshSession(),
+        guessHistory: [{ guess: 'AUDIO', result: [], timestamp: new Date() }],
+      });
+
+      // Should not throw for valid words
+      await expect(
+        service.submitGuess(1, { guess: 'AUDIO' }),
+      ).resolves.toBeDefined();
+
+      // Reset for next call
+      mockRepository.findOne.mockResolvedValueOnce(freshSession());
+      mockRepository.save.mockResolvedValueOnce({
+        ...freshSession(),
+        guessHistory: [{ guess: 'WORLD', result: [], timestamp: new Date() }],
+      });
+
+      await expect(
+        service.submitGuess(1, { guess: 'WORLD' }),
+      ).resolves.toBeDefined();
+
+      // Reset for next call
+      mockRepository.findOne.mockResolvedValueOnce(freshSession());
+      mockRepository.save.mockResolvedValueOnce({
+        ...freshSession(),
+        guessHistory: [{ guess: 'CRANE', result: [], timestamp: new Date() }],
+      });
+
+      await expect(
+        service.submitGuess(1, { guess: 'CRANE' }),
+      ).resolves.toBeDefined();
+    });
+
+    it('should reject invalid words not in dictionary', async () => {
+      const session = { ...mockWordleSession };
+      mockRepository.findOne.mockResolvedValue(session);
+
+      // Should throw for invalid words
+      await expect(service.submitGuess(1, { guess: 'AAAAA' })).rejects.toThrow(
+        BadRequestException,
+      );
+      await expect(service.submitGuess(1, { guess: 'AAAAA' })).rejects.toThrow(
+        'Not in word list',
+      );
+
+      await expect(service.submitGuess(1, { guess: 'ZZZZZ' })).rejects.toThrow(
+        BadRequestException,
+      );
+      await expect(service.submitGuess(1, { guess: 'ZZZZZ' })).rejects.toThrow(
+        'Not in word list',
+      );
+
+      await expect(service.submitGuess(1, { guess: 'NOTWD' })).rejects.toThrow(
+        BadRequestException,
+      );
+      await expect(service.submitGuess(1, { guess: 'NOTWD' })).rejects.toThrow(
+        'Not in word list',
+      );
+    });
+
+    it('should handle case insensitive validation', async () => {
+      const session = { ...mockWordleSession };
+      mockRepository.findOne.mockResolvedValue(session);
+      mockRepository.save.mockResolvedValue({
+        ...session,
+        guessHistory: [{ guess: 'AUDIO', result: [], timestamp: new Date() }],
+      });
+
+      // Should accept lowercase and mixed case valid words
+      await expect(
+        service.submitGuess(1, { guess: 'audio' }),
+      ).resolves.toBeDefined();
+      await expect(
+        service.submitGuess(1, { guess: 'Audio' }),
+      ).resolves.toBeDefined();
+      await expect(
+        service.submitGuess(1, { guess: 'AUDIO' }),
+      ).resolves.toBeDefined();
+
+      // Should reject lowercase invalid words
+      await expect(service.submitGuess(1, { guess: 'aaaaa' })).rejects.toThrow(
+        'Not in word list',
+      );
+    });
+
+    it('should validate words before game logic checks', async () => {
+      const completedSession = {
+        ...mockWordleSession,
+        isCompleted: true,
+      };
+      mockRepository.findOne.mockResolvedValue(completedSession);
+
+      // Invalid word should be caught before "game completed" error
+      await expect(service.submitGuess(1, { guess: 'AAAAA' })).rejects.toThrow(
+        'Not in word list',
+      );
+    });
+
+    it('should validate words before length checks', async () => {
+      const session = { ...mockWordleSession };
+      mockRepository.findOne.mockResolvedValue(session);
+
+      // Test that word validation happens before length validation
+      // by using a 5-letter invalid word
+      await expect(service.submitGuess(1, { guess: 'AAAAA' })).rejects.toThrow(
+        'Not in word list',
+      );
+
+      // And that length validation still works for invalid lengths
+      await expect(service.submitGuess(1, { guess: 'ABC' })).rejects.toThrow(
+        'Guess must be exactly 5 letters long',
+      );
+    });
+
+    it('should not save invalid word guesses to history', async () => {
+      const session = { ...mockWordleSession };
+      mockRepository.findOne.mockResolvedValue(session);
+
+      try {
+        await service.submitGuess(1, { guess: 'AAAAA' });
+      } catch {
+        // Verify repository save was never called for invalid word
+        expect(mockRepository.save).not.toHaveBeenCalled();
+      }
+
+      expect.assertions(1);
+    });
+
+    it('should not decrement attempts for invalid words', async () => {
+      const session = { ...mockWordleSession, attemptsRemaining: 3 };
+      mockRepository.findOne.mockResolvedValue(session);
+
+      try {
+        await service.submitGuess(1, { guess: 'AAAAA' });
+      } catch {
+        // Verify that attempts were not decremented
+        expect(mockRepository.save).not.toHaveBeenCalledWith(
+          expect.objectContaining({
+            attemptsRemaining: 2,
+          }),
+        );
+      }
+
+      expect.assertions(1);
+    });
+  });
+
+  describe('Dictionary Service Integration', () => {
+    it('should correctly identify valid words from file', () => {
+      expect(dictionaryService.isValidWord('WORLD')).toBe(true);
+      expect(dictionaryService.isValidWord('AUDIO')).toBe(true);
+      expect(dictionaryService.isValidWord('CRANE')).toBe(true);
+      expect(dictionaryService.isValidWord('TRACE')).toBe(true);
+      expect(dictionaryService.isValidWord('BREAD')).toBe(true);
+    });
+
+    it('should correctly identify invalid words', () => {
+      expect(dictionaryService.isValidWord('AAAAA')).toBe(false);
+      expect(dictionaryService.isValidWord('ZZZZZ')).toBe(false);
+      expect(dictionaryService.isValidWord('NOTWD')).toBe(false);
+    });
+
+    it('should have loaded correct word count', () => {
+      expect(dictionaryService.getWordCount()).toBe(5);
+    });
+  });
+});

--- a/backend/src/dewordle/wordle-session.controller.spec.ts
+++ b/backend/src/dewordle/wordle-session.controller.spec.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-unsafe-assignment */
 import { Test, TestingModule } from '@nestjs/testing';
 import { NotFoundException, BadRequestException } from '@nestjs/common';
 import { WordleSessionController } from './wordle-session.controller';
@@ -151,6 +150,20 @@ describe('WordleSessionController', () => {
       ).rejects.toThrow(NotFoundException);
 
       expect(mockService.submitGuess).not.toHaveBeenCalled();
+    });
+
+    it('should handle invalid word validation from service', async () => {
+      mockService.submitGuess.mockRejectedValue(
+        new BadRequestException('Not in word list'),
+      );
+
+      await expect(
+        controller.submitGuess('1', { guess: 'AAAAA' }),
+      ).rejects.toThrow(BadRequestException);
+
+      expect(mockService.submitGuess).toHaveBeenCalledWith(1, {
+        guess: 'AAAAA',
+      });
     });
   });
 });

--- a/backend/src/dewordle/wordle-session.controller.spec.ts
+++ b/backend/src/dewordle/wordle-session.controller.spec.ts
@@ -1,0 +1,156 @@
+/* eslint-disable @typescript-eslint/no-unsafe-assignment */
+import { Test, TestingModule } from '@nestjs/testing';
+import { NotFoundException, BadRequestException } from '@nestjs/common';
+import { WordleSessionController } from './wordle-session.controller';
+import { WordleSessionService } from './wordle-session.service';
+import { WordleSession } from './entities/wordle-session.entity';
+import { Word } from '../entities/word.entity';
+
+describe('WordleSessionController', () => {
+  let controller: WordleSessionController;
+
+  const mockWordleSession: WordleSession = {
+    id: 1,
+    user: null,
+    targetWord: {
+      id: 'test-word-id',
+      word: 'WORLD',
+    } as Word,
+    guessHistory: [
+      {
+        guess: 'AUDIO',
+        result: [
+          { letter: 'A', status: 'absent' },
+          { letter: 'U', status: 'absent' },
+          { letter: 'D', status: 'present' },
+          { letter: 'I', status: 'absent' },
+          { letter: 'O', status: 'present' },
+        ],
+        timestamp: new Date('2024-01-15T10:30:00.000Z'),
+      },
+    ],
+    isCompleted: false,
+    isWon: false,
+    attemptsRemaining: 5,
+    completedAt: null,
+    createdAt: new Date('2024-01-15T10:00:00.000Z'),
+    updatedAt: new Date('2024-01-15T10:30:00.000Z'),
+  };
+
+  const mockService = {
+    submitGuess: jest.fn(),
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [WordleSessionController],
+      providers: [
+        {
+          provide: WordleSessionService,
+          useValue: mockService,
+        },
+      ],
+    }).compile();
+
+    controller = module.get<WordleSessionController>(WordleSessionController);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('submitGuess', () => {
+    it('should successfully submit a guess', async () => {
+      mockService.submitGuess.mockResolvedValue(mockWordleSession);
+
+      const result = await controller.submitGuess('1', { guess: 'AUDIO' });
+
+      expect(mockService.submitGuess).toHaveBeenCalledWith(1, {
+        guess: 'AUDIO',
+      });
+      expect(result).toEqual(mockWordleSession);
+    });
+
+    it('should throw NotFoundException for invalid session ID format', async () => {
+      await expect(
+        controller.submitGuess('invalid', { guess: 'AUDIO' }),
+      ).rejects.toThrow(NotFoundException);
+
+      expect(mockService.submitGuess).not.toHaveBeenCalled();
+    });
+
+    it('should handle service throwing NotFoundException', async () => {
+      mockService.submitGuess.mockRejectedValue(
+        new NotFoundException('Wordle session not found'),
+      );
+
+      await expect(
+        controller.submitGuess('999', { guess: 'AUDIO' }),
+      ).rejects.toThrow(NotFoundException);
+
+      expect(mockService.submitGuess).toHaveBeenCalledWith(999, {
+        guess: 'AUDIO',
+      });
+    });
+
+    it('should handle service throwing BadRequestException', async () => {
+      mockService.submitGuess.mockRejectedValue(
+        new BadRequestException('Game session is already completed'),
+      );
+
+      await expect(
+        controller.submitGuess('1', { guess: 'AUDIO' }),
+      ).rejects.toThrow(BadRequestException);
+
+      expect(mockService.submitGuess).toHaveBeenCalledWith(1, {
+        guess: 'AUDIO',
+      });
+    });
+
+    it('should convert string session ID to number', async () => {
+      mockService.submitGuess.mockResolvedValue(mockWordleSession);
+
+      await controller.submitGuess('123', { guess: 'WORLD' });
+
+      expect(mockService.submitGuess).toHaveBeenCalledWith(123, {
+        guess: 'WORLD',
+      });
+    });
+
+    it('should handle edge case session IDs', () => {
+      // Test with '0'
+      expect(
+        async () => await controller.submitGuess('0', { guess: 'AUDIO' }),
+      ).not.toThrow();
+
+      expect(mockService.submitGuess).toHaveBeenCalledWith(0, {
+        guess: 'AUDIO',
+      });
+
+      // Test with negative number string
+      expect(
+        async () => await controller.submitGuess('-1', { guess: 'AUDIO' }),
+      ).not.toThrow();
+
+      expect(mockService.submitGuess).toHaveBeenCalledWith(-1, {
+        guess: 'AUDIO',
+      });
+    });
+
+    it('should handle non-numeric session ID', async () => {
+      await expect(
+        controller.submitGuess('abc', { guess: 'AUDIO' }),
+      ).rejects.toThrow(NotFoundException);
+
+      expect(mockService.submitGuess).not.toHaveBeenCalled();
+    });
+
+    it('should handle empty session ID', async () => {
+      await expect(
+        controller.submitGuess('', { guess: 'AUDIO' }),
+      ).rejects.toThrow(NotFoundException);
+
+      expect(mockService.submitGuess).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/backend/src/dewordle/wordle-session.controller.ts
+++ b/backend/src/dewordle/wordle-session.controller.ts
@@ -1,0 +1,116 @@
+import {
+  Controller,
+  Post,
+  Param,
+  Body,
+  HttpCode,
+  HttpStatus,
+  NotFoundException,
+} from '@nestjs/common';
+import {
+  ApiTags,
+  ApiOperation,
+  ApiResponse,
+  ApiParam,
+  ApiBody,
+} from '@nestjs/swagger';
+import { WordleSessionService } from './wordle-session.service';
+import { SubmitGuessDto } from './dto/submit-guess.dto';
+import { WordleSession } from './entities/wordle-session.entity';
+
+@ApiTags('Wordle Sessions')
+@Controller('wordle-sessions')
+export class WordleSessionController {
+  constructor(private readonly wordleSessionService: WordleSessionService) {}
+
+  @Post(':id/guess')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({
+    summary: 'Submit a guess for a wordle session',
+    description:
+      'Submit a 5-letter word guess for the specified wordle session. The guess will be evaluated against the target word and the session will be updated with the result.',
+  })
+  @ApiParam({
+    name: 'id',
+    description: 'The ID of the wordle session',
+    type: 'number',
+    example: 123,
+  })
+  @ApiBody({
+    type: SubmitGuessDto,
+    description: 'The guess to submit',
+    examples: {
+      example1: {
+        summary: 'Submit guess',
+        value: {
+          guess: 'AUDIO',
+        },
+      },
+    },
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Guess submitted successfully',
+    schema: {
+      example: {
+        id: 123,
+        guessHistory: [
+          {
+            guess: 'AUDIO',
+            result: [
+              { letter: 'A', status: 'absent' },
+              { letter: 'U', status: 'present' },
+              { letter: 'D', status: 'absent' },
+              { letter: 'I', status: 'correct' },
+              { letter: 'O', status: 'absent' },
+            ],
+            timestamp: '2024-01-15T10:30:00.000Z',
+          },
+        ],
+        isCompleted: false,
+        isWon: false,
+        attemptsRemaining: 5,
+        targetWord: {
+          id: 'uuid-string',
+          word: 'SUITE',
+        },
+        createdAt: '2024-01-15T10:00:00.000Z',
+        updatedAt: '2024-01-15T10:30:00.000Z',
+      },
+    },
+  })
+  @ApiResponse({
+    status: 404,
+    description: 'Wordle session not found',
+    schema: {
+      example: {
+        statusCode: 404,
+        message: 'Wordle session not found',
+        error: 'Not Found',
+      },
+    },
+  })
+  @ApiResponse({
+    status: 400,
+    description: 'Bad request - Invalid guess or session already completed',
+    schema: {
+      example: {
+        statusCode: 400,
+        message: 'Game session is already completed',
+        error: 'Bad Request',
+      },
+    },
+  })
+  async submitGuess(
+    @Param('id') sessionId: string,
+    @Body() submitGuessDto: SubmitGuessDto,
+  ): Promise<WordleSession> {
+    const id = parseInt(sessionId, 10);
+
+    if (isNaN(id)) {
+      throw new NotFoundException('Invalid session ID');
+    }
+
+    return await this.wordleSessionService.submitGuess(id, submitGuessDto);
+  }
+}

--- a/backend/src/dewordle/wordle-session.e2e-spec.ts
+++ b/backend/src/dewordle/wordle-session.e2e-spec.ts
@@ -1,0 +1,222 @@
+/* eslint-disable @typescript-eslint/no-unsafe-assignment */
+/* eslint-disable @typescript-eslint/no-unsafe-argument */
+/* eslint-disable @typescript-eslint/no-unsafe-member-access */
+/* eslint-disable @typescript-eslint/no-unused-vars */
+import { Test, TestingModule } from '@nestjs/testing';
+import { INestApplication } from '@nestjs/common';
+import * as request from 'supertest';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { WordleSessionModule } from './wordle-session.module';
+import { WordleSession } from './entities/wordle-session.entity';
+import { Word } from '../entities/word.entity';
+
+describe('WordleSession E2E', () => {
+  let app: INestApplication;
+
+  const mockWordleSession: WordleSession = {
+    id: 1,
+    user: null,
+    targetWord: {
+      id: 'test-word-id',
+      word: 'WORLD',
+    } as Word,
+    guessHistory: [],
+    isCompleted: false,
+    isWon: false,
+    attemptsRemaining: 6,
+    completedAt: null,
+    createdAt: new Date('2024-01-15T10:00:00.000Z'),
+    updatedAt: new Date('2024-01-15T10:00:00.000Z'),
+  };
+
+  const mockRepository = {
+    findOne: jest.fn(),
+    save: jest.fn(),
+  };
+
+  beforeAll(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [WordleSessionModule],
+    })
+      .overrideProvider(getRepositoryToken(WordleSession))
+      .useValue(mockRepository)
+      .compile();
+
+    app = moduleFixture.createNestApplication();
+    await app.init();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('POST /wordle-sessions/:id/guess', () => {
+    it('should successfully submit a guess', async () => {
+      const session = { ...mockWordleSession };
+      const updatedSession = {
+        ...session,
+        guessHistory: [
+          {
+            guess: 'AUDIO',
+            result: [
+              { letter: 'A', status: 'absent' },
+              { letter: 'U', status: 'absent' },
+              { letter: 'D', status: 'present' },
+              { letter: 'I', status: 'absent' },
+              { letter: 'O', status: 'present' },
+            ],
+            timestamp: expect.any(Date),
+          },
+        ],
+        attemptsRemaining: 5,
+        updatedAt: expect.any(Date),
+      };
+
+      mockRepository.findOne.mockResolvedValue(session);
+      mockRepository.save.mockResolvedValue(updatedSession);
+
+      const response = await request(app.getHttpServer())
+        .post('/wordle-sessions/1/guess')
+        .send({ guess: 'AUDIO' })
+        .expect(200);
+
+      expect(response.body).toMatchObject({
+        id: 1,
+        attemptsRemaining: 5,
+        isCompleted: false,
+        isWon: false,
+        guessHistory: [
+          {
+            guess: 'AUDIO',
+            result: [
+              { letter: 'A', status: 'absent' },
+              { letter: 'U', status: 'absent' },
+              { letter: 'D', status: 'present' },
+              { letter: 'I', status: 'absent' },
+              { letter: 'O', status: 'present' },
+            ],
+          },
+        ],
+      });
+    });
+
+    it('should return 404 for non-existent session', async () => {
+      mockRepository.findOne.mockResolvedValue(null);
+
+      const response = await request(app.getHttpServer())
+        .post('/wordle-sessions/999/guess')
+        .send({ guess: 'AUDIO' })
+        .expect(404);
+
+      expect(response.body).toMatchObject({
+        statusCode: 404,
+        message: 'Wordle session not found',
+      });
+    });
+
+    it('should return 400 for completed session', async () => {
+      const completedSession = {
+        ...mockWordleSession,
+        isCompleted: true,
+      };
+
+      mockRepository.findOne.mockResolvedValue(completedSession);
+
+      const response = await request(app.getHttpServer())
+        .post('/wordle-sessions/1/guess')
+        .send({ guess: 'AUDIO' })
+        .expect(400);
+
+      expect(response.body).toMatchObject({
+        statusCode: 400,
+        message: 'Game session is already completed',
+      });
+    });
+
+    it('should return 400 for invalid guess format', async () => {
+      const response = await request(app.getHttpServer())
+        .post('/wordle-sessions/1/guess')
+        .send({ guess: 'ABC' })
+        .expect(400);
+
+      expect(response.body.message).toContain(
+        'Guess must be exactly 5 letters long',
+      );
+    });
+
+    it('should return 400 for empty guess', async () => {
+      const response = await request(app.getHttpServer())
+        .post('/wordle-sessions/1/guess')
+        .send({ guess: '' })
+        .expect(400);
+
+      expect(response.body.message).toContain(
+        'Guess must be exactly 5 letters long',
+      );
+    });
+
+    it('should return 400 for missing guess', async () => {
+      const response = await request(app.getHttpServer())
+        .post('/wordle-sessions/1/guess')
+        .send({})
+        .expect(400);
+
+      expect(response.body.message).toContain('guess');
+    });
+
+    it('should return 404 for invalid session ID format', async () => {
+      const response = await request(app.getHttpServer())
+        .post('/wordle-sessions/invalid/guess')
+        .send({ guess: 'AUDIO' })
+        .expect(404);
+
+      expect(response.body).toMatchObject({
+        statusCode: 404,
+        message: 'Invalid session ID',
+      });
+    });
+
+    it('should handle winning guess', async () => {
+      const session = { ...mockWordleSession };
+      const updatedSession = {
+        ...session,
+        guessHistory: [
+          {
+            guess: 'WORLD',
+            result: [
+              { letter: 'W', status: 'correct' },
+              { letter: 'O', status: 'correct' },
+              { letter: 'R', status: 'correct' },
+              { letter: 'L', status: 'correct' },
+              { letter: 'D', status: 'correct' },
+            ],
+            timestamp: expect.any(Date),
+          },
+        ],
+        isWon: true,
+        isCompleted: true,
+        attemptsRemaining: 5,
+        completedAt: expect.any(Date),
+      };
+
+      mockRepository.findOne.mockResolvedValue(session);
+      mockRepository.save.mockResolvedValue(updatedSession);
+
+      const response = await request(app.getHttpServer())
+        .post('/wordle-sessions/1/guess')
+        .send({ guess: 'WORLD' })
+        .expect(200);
+
+      expect(response.body).toMatchObject({
+        id: 1,
+        isWon: true,
+        isCompleted: true,
+        attemptsRemaining: 5,
+      });
+    });
+  });
+});

--- a/backend/src/dewordle/wordle-session.module.ts
+++ b/backend/src/dewordle/wordle-session.module.ts
@@ -3,11 +3,12 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { WordleSession } from './entities/wordle-session.entity';
 import { WordleSessionController } from './wordle-session.controller';
 import { WordleSessionService } from './wordle-session.service';
+import { DictionaryService } from './dictionary.service';
 
 @Module({
   imports: [TypeOrmModule.forFeature([WordleSession])],
   controllers: [WordleSessionController],
-  providers: [WordleSessionService],
+  providers: [WordleSessionService, DictionaryService],
   exports: [WordleSessionService],
 })
 export class WordleSessionModule {}

--- a/backend/src/dewordle/wordle-session.module.ts
+++ b/backend/src/dewordle/wordle-session.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { WordleSession } from './entities/wordle-session.entity';
+import { WordleSessionController } from './wordle-session.controller';
+import { WordleSessionService } from './wordle-session.service';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([WordleSession])],
+  controllers: [WordleSessionController],
+  providers: [WordleSessionService],
+  exports: [WordleSessionService],
+})
+export class WordleSessionModule {}

--- a/backend/src/dewordle/wordle-session.service.spec.ts
+++ b/backend/src/dewordle/wordle-session.service.spec.ts
@@ -1,11 +1,11 @@
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
-/* eslint-disable @typescript-eslint/no-unused-vars */
 import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
 import { NotFoundException, BadRequestException } from '@nestjs/common';
 import { WordleSessionService } from './wordle-session.service';
 import { WordleSession } from './entities/wordle-session.entity';
 import { Word } from '../entities/word.entity';
+import { DictionaryService } from './dictionary.service';
 
 describe('WordleSessionService', () => {
   let service: WordleSessionService;
@@ -31,6 +31,10 @@ describe('WordleSessionService', () => {
     save: jest.fn(),
   };
 
+  const mockDictionaryService = {
+    isValidWord: jest.fn(),
+  };
+
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
@@ -38,6 +42,10 @@ describe('WordleSessionService', () => {
         {
           provide: getRepositoryToken(WordleSession),
           useValue: mockRepository,
+        },
+        {
+          provide: DictionaryService,
+          useValue: mockDictionaryService,
         },
       ],
     }).compile();
@@ -99,6 +107,7 @@ describe('WordleSessionService', () => {
 
       mockRepository.findOne.mockResolvedValue(session);
       mockRepository.save.mockResolvedValue(updatedSession);
+      mockDictionaryService.isValidWord.mockReturnValue(true);
 
       const result = await service.submitGuess(1, { guess: 'WORLD' });
 
@@ -106,6 +115,7 @@ describe('WordleSessionService', () => {
         where: { id: 1 },
         relations: ['targetWord', 'user'],
       });
+      expect(mockDictionaryService.isValidWord).toHaveBeenCalledWith('WORLD');
       expect(mockRepository.save).toHaveBeenCalledWith(
         expect.objectContaining({
           isWon: true,
@@ -150,6 +160,7 @@ describe('WordleSessionService', () => {
 
       mockRepository.findOne.mockResolvedValue(session);
       mockRepository.save.mockResolvedValue(updatedSession);
+      mockDictionaryService.isValidWord.mockReturnValue(true);
 
       const result = await service.submitGuess(1, { guess: 'AUDIO' });
 
@@ -181,6 +192,7 @@ describe('WordleSessionService', () => {
 
       mockRepository.findOne.mockResolvedValue(session);
       mockRepository.save.mockResolvedValue(updatedSession);
+      mockDictionaryService.isValidWord.mockReturnValue(true);
 
       const result = await service.submitGuess(1, { guess: 'AUDIO' });
 
@@ -223,6 +235,20 @@ describe('WordleSessionService', () => {
       );
     });
 
+    it('should throw BadRequestException for invalid word not in dictionary', async () => {
+      mockRepository.findOne.mockResolvedValue(mockWordleSession);
+      mockDictionaryService.isValidWord.mockReturnValue(false);
+
+      await expect(service.submitGuess(1, { guess: 'AAAAA' })).rejects.toThrow(
+        BadRequestException,
+      );
+      await expect(service.submitGuess(1, { guess: 'AAAAA' })).rejects.toThrow(
+        'Not in word list',
+      );
+
+      expect(mockDictionaryService.isValidWord).toHaveBeenCalledWith('AAAAA');
+    });
+
     it('should normalize guess to uppercase', async () => {
       const session = { ...mockWordleSession };
       mockRepository.findOne.mockResolvedValue(session);
@@ -230,6 +256,7 @@ describe('WordleSessionService', () => {
         ...session,
         guessHistory: [{ guess: 'AUDIO', result: [], timestamp: new Date() }],
       });
+      mockDictionaryService.isValidWord.mockReturnValue(true);
 
       await service.submitGuess(1, { guess: 'audio' });
 

--- a/backend/src/dewordle/wordle-session.service.spec.ts
+++ b/backend/src/dewordle/wordle-session.service.spec.ts
@@ -1,0 +1,255 @@
+/* eslint-disable @typescript-eslint/no-unsafe-assignment */
+/* eslint-disable @typescript-eslint/no-unused-vars */
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { NotFoundException, BadRequestException } from '@nestjs/common';
+import { WordleSessionService } from './wordle-session.service';
+import { WordleSession } from './entities/wordle-session.entity';
+import { Word } from '../entities/word.entity';
+
+describe('WordleSessionService', () => {
+  let service: WordleSessionService;
+
+  const mockWordleSession: WordleSession = {
+    id: 1,
+    user: null,
+    targetWord: {
+      id: 'test-word-id',
+      word: 'WORLD',
+    } as Word,
+    guessHistory: [],
+    isCompleted: false,
+    isWon: false,
+    attemptsRemaining: 6,
+    completedAt: null,
+    createdAt: new Date('2024-01-15T10:00:00.000Z'),
+    updatedAt: new Date('2024-01-15T10:00:00.000Z'),
+  };
+
+  const mockRepository = {
+    findOne: jest.fn(),
+    save: jest.fn(),
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        WordleSessionService,
+        {
+          provide: getRepositoryToken(WordleSession),
+          useValue: mockRepository,
+        },
+      ],
+    }).compile();
+
+    service = module.get<WordleSessionService>(WordleSessionService);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('findById', () => {
+    it('should return a wordle session when found', async () => {
+      mockRepository.findOne.mockResolvedValue(mockWordleSession);
+
+      const result = await service.findById(1);
+
+      expect(mockRepository.findOne).toHaveBeenCalledWith({
+        where: { id: 1 },
+        relations: ['targetWord', 'user'],
+      });
+      expect(result).toEqual(mockWordleSession);
+    });
+
+    it('should throw NotFoundException when session not found', async () => {
+      mockRepository.findOne.mockResolvedValue(null);
+
+      await expect(service.findById(999)).rejects.toThrow(NotFoundException);
+      expect(mockRepository.findOne).toHaveBeenCalledWith({
+        where: { id: 999 },
+        relations: ['targetWord', 'user'],
+      });
+    });
+  });
+
+  describe('submitGuess', () => {
+    it('should successfully submit a correct guess and win the game', async () => {
+      const session = { ...mockWordleSession };
+      const updatedSession = {
+        ...session,
+        guessHistory: [
+          {
+            guess: 'WORLD',
+            result: [
+              { letter: 'W', status: 'correct' },
+              { letter: 'O', status: 'correct' },
+              { letter: 'R', status: 'correct' },
+              { letter: 'L', status: 'correct' },
+              { letter: 'D', status: 'correct' },
+            ],
+            timestamp: expect.any(Date),
+          },
+        ],
+        isWon: true,
+        isCompleted: true,
+        attemptsRemaining: 5,
+        completedAt: expect.any(Date),
+      };
+
+      mockRepository.findOne.mockResolvedValue(session);
+      mockRepository.save.mockResolvedValue(updatedSession);
+
+      const result = await service.submitGuess(1, { guess: 'WORLD' });
+
+      expect(mockRepository.findOne).toHaveBeenCalledWith({
+        where: { id: 1 },
+        relations: ['targetWord', 'user'],
+      });
+      expect(mockRepository.save).toHaveBeenCalledWith(
+        expect.objectContaining({
+          isWon: true,
+          isCompleted: true,
+          attemptsRemaining: 5,
+          guessHistory: expect.arrayContaining([
+            expect.objectContaining({
+              guess: 'WORLD',
+              result: expect.arrayContaining([
+                { letter: 'W', status: 'correct' },
+                { letter: 'O', status: 'correct' },
+                { letter: 'R', status: 'correct' },
+                { letter: 'L', status: 'correct' },
+                { letter: 'D', status: 'correct' },
+              ]),
+            }),
+          ]),
+        }),
+      );
+      expect(result).toEqual(updatedSession);
+    });
+
+    it('should successfully submit an incorrect guess', async () => {
+      const session = { ...mockWordleSession };
+      const updatedSession = {
+        ...session,
+        guessHistory: [
+          {
+            guess: 'AUDIO',
+            result: [
+              { letter: 'A', status: 'absent' },
+              { letter: 'U', status: 'absent' },
+              { letter: 'D', status: 'present' },
+              { letter: 'I', status: 'absent' },
+              { letter: 'O', status: 'present' },
+            ],
+            timestamp: expect.any(Date),
+          },
+        ],
+        attemptsRemaining: 5,
+      };
+
+      mockRepository.findOne.mockResolvedValue(session);
+      mockRepository.save.mockResolvedValue(updatedSession);
+
+      const result = await service.submitGuess(1, { guess: 'AUDIO' });
+
+      expect(result.attemptsRemaining).toBe(5);
+      expect(result.isWon).toBe(false);
+      expect(result.isCompleted).toBe(false);
+      expect(result.guessHistory).toHaveLength(1);
+      expect(result.guessHistory[0].guess).toBe('AUDIO');
+    });
+
+    it('should complete the game when no attempts remaining', async () => {
+      const session = {
+        ...mockWordleSession,
+        attemptsRemaining: 1,
+      };
+      const updatedSession = {
+        ...session,
+        attemptsRemaining: 0,
+        isCompleted: true,
+        completedAt: expect.any(Date),
+        guessHistory: [
+          {
+            guess: 'AUDIO',
+            result: expect.any(Array),
+            timestamp: expect.any(Date),
+          },
+        ],
+      };
+
+      mockRepository.findOne.mockResolvedValue(session);
+      mockRepository.save.mockResolvedValue(updatedSession);
+
+      const result = await service.submitGuess(1, { guess: 'AUDIO' });
+
+      expect(result.attemptsRemaining).toBe(0);
+      expect(result.isCompleted).toBe(true);
+      expect(result.isWon).toBe(false);
+    });
+
+    it('should throw BadRequestException when session is already completed', async () => {
+      const completedSession = {
+        ...mockWordleSession,
+        isCompleted: true,
+      };
+
+      mockRepository.findOne.mockResolvedValue(completedSession);
+
+      await expect(service.submitGuess(1, { guess: 'AUDIO' })).rejects.toThrow(
+        BadRequestException,
+      );
+    });
+
+    it('should throw BadRequestException when no attempts remaining', async () => {
+      const noAttemptsSession = {
+        ...mockWordleSession,
+        attemptsRemaining: 0,
+      };
+
+      mockRepository.findOne.mockResolvedValue(noAttemptsSession);
+
+      await expect(service.submitGuess(1, { guess: 'AUDIO' })).rejects.toThrow(
+        BadRequestException,
+      );
+    });
+
+    it('should throw BadRequestException for invalid guess length', async () => {
+      mockRepository.findOne.mockResolvedValue(mockWordleSession);
+
+      await expect(service.submitGuess(1, { guess: 'ABC' })).rejects.toThrow(
+        BadRequestException,
+      );
+    });
+
+    it('should normalize guess to uppercase', async () => {
+      const session = { ...mockWordleSession };
+      mockRepository.findOne.mockResolvedValue(session);
+      mockRepository.save.mockResolvedValue({
+        ...session,
+        guessHistory: [{ guess: 'AUDIO', result: [], timestamp: new Date() }],
+      });
+
+      await service.submitGuess(1, { guess: 'audio' });
+
+      expect(mockRepository.save).toHaveBeenCalledWith(
+        expect.objectContaining({
+          guessHistory: expect.arrayContaining([
+            expect.objectContaining({
+              guess: 'AUDIO',
+            }),
+          ]),
+        }),
+      );
+    });
+
+    it('should handle session not found', async () => {
+      mockRepository.findOne.mockResolvedValue(null);
+
+      await expect(
+        service.submitGuess(999, { guess: 'AUDIO' }),
+      ).rejects.toThrow(NotFoundException);
+    });
+  });
+});

--- a/backend/src/dewordle/wordle-session.service.ts
+++ b/backend/src/dewordle/wordle-session.service.ts
@@ -1,0 +1,88 @@
+import {
+  Injectable,
+  NotFoundException,
+  BadRequestException,
+} from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { WordleSession, GuessHistory } from './entities/wordle-session.entity';
+import { SubmitGuessDto } from './dto/submit-guess.dto';
+import { evaluateGuess } from './wordle.engine';
+
+@Injectable()
+export class WordleSessionService {
+  constructor(
+    @InjectRepository(WordleSession)
+    private readonly wordleSessionRepo: Repository<WordleSession>,
+  ) {}
+
+  async findById(id: number): Promise<WordleSession> {
+    const session = await this.wordleSessionRepo.findOne({
+      where: { id },
+      relations: ['targetWord', 'user'],
+    });
+
+    if (!session) {
+      throw new NotFoundException('Wordle session not found');
+    }
+
+    return session;
+  }
+
+  async submitGuess(
+    sessionId: number,
+    submitGuessDto: SubmitGuessDto,
+  ): Promise<WordleSession> {
+    const session = await this.findById(sessionId);
+
+    // Validate session is not completed
+    if (session.isCompleted) {
+      throw new BadRequestException('Game session is already completed');
+    }
+
+    // Validate attempts remaining
+    if (session.attemptsRemaining <= 0) {
+      throw new BadRequestException('No attempts remaining');
+    }
+
+    // Normalize guess to uppercase
+    const guess = submitGuessDto.guess.toUpperCase().trim();
+
+    // Validate guess length (additional validation)
+    if (guess.length !== 5) {
+      throw new BadRequestException('Guess must be exactly 5 letters long');
+    }
+
+    // Evaluate the guess using the wordle engine
+    const result = evaluateGuess(guess, session.targetWord.word);
+
+    // Create guess history entry
+    const guessEntry: GuessHistory = {
+      guess,
+      result,
+      timestamp: new Date(),
+    };
+
+    // Update session
+    session.guessHistory = [...session.guessHistory, guessEntry];
+    session.attemptsRemaining -= 1;
+
+    // Check if won (all letters are correct)
+    const isWon = result.every(
+      (letterResult) => letterResult.status === 'correct',
+    );
+
+    if (isWon) {
+      session.isWon = true;
+      session.isCompleted = true;
+      session.completedAt = new Date();
+    } else if (session.attemptsRemaining === 0) {
+      // Game over - no more attempts
+      session.isCompleted = true;
+      session.completedAt = new Date();
+    }
+
+    // Save and return updated session
+    return await this.wordleSessionRepo.save(session);
+  }
+}

--- a/backend/src/dewordle/wordle-session.service.ts
+++ b/backend/src/dewordle/wordle-session.service.ts
@@ -8,12 +8,14 @@ import { Repository } from 'typeorm';
 import { WordleSession, GuessHistory } from './entities/wordle-session.entity';
 import { SubmitGuessDto } from './dto/submit-guess.dto';
 import { evaluateGuess } from './wordle.engine';
+import { DictionaryService } from './dictionary.service';
 
 @Injectable()
 export class WordleSessionService {
   constructor(
     @InjectRepository(WordleSession)
     private readonly wordleSessionRepo: Repository<WordleSession>,
+    private readonly dictionaryService: DictionaryService,
   ) {}
 
   async findById(id: number): Promise<WordleSession> {
@@ -35,6 +37,19 @@ export class WordleSessionService {
   ): Promise<WordleSession> {
     const session = await this.findById(sessionId);
 
+    // Normalize guess to uppercase
+    const guess = submitGuessDto.guess.toUpperCase().trim();
+
+    // Validate guess length (additional validation)
+    if (guess.length !== 5) {
+      throw new BadRequestException('Guess must be exactly 5 letters long');
+    }
+
+    // Validate that the guess is a valid word in the dictionary
+    if (!this.dictionaryService.isValidWord(guess)) {
+      throw new BadRequestException('Not in word list');
+    }
+
     // Validate session is not completed
     if (session.isCompleted) {
       throw new BadRequestException('Game session is already completed');
@@ -43,14 +58,6 @@ export class WordleSessionService {
     // Validate attempts remaining
     if (session.attemptsRemaining <= 0) {
       throw new BadRequestException('No attempts remaining');
-    }
-
-    // Normalize guess to uppercase
-    const guess = submitGuessDto.guess.toUpperCase().trim();
-
-    // Validate guess length (additional validation)
-    if (guess.length !== 5) {
-      throw new BadRequestException('Guess must be exactly 5 letters long');
     }
 
     // Evaluate the guess using the wordle engine

--- a/backend/src/game-sessions/entities/game-session.entity.ts
+++ b/backend/src/game-sessions/entities/game-session.entity.ts
@@ -6,7 +6,7 @@ import {
   CreateDateColumn,
 } from 'typeorm';
 import { Game } from '../../games/entities/game.entity';
-import { User } from 'src/auth/entities/user.entity';
+import { User } from '../../auth/entities/user.entity';
 
 @Entity()
 export class GameSession {

--- a/backend/src/games/entities/game.entity.ts
+++ b/backend/src/games/entities/game.entity.ts
@@ -1,4 +1,4 @@
-import { GameSession } from 'src/game-sessions/entities/game-session.entity';
+import { GameSession } from '../../game-sessions/entities/game-session.entity';
 import {
   Column,
   Entity,

--- a/backend/src/migrations/1737215000000-CreateWordleSessionsTable.ts
+++ b/backend/src/migrations/1737215000000-CreateWordleSessionsTable.ts
@@ -1,0 +1,107 @@
+import { MigrationInterface, QueryRunner, Table } from 'typeorm';
+
+export class CreateWordleSessionsTable1737215000000
+  implements MigrationInterface
+{
+  name = 'CreateWordleSessionsTable1737215000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.createTable(
+      new Table({
+        name: 'wordle_sessions',
+        columns: [
+          {
+            name: 'id',
+            type: 'int',
+            isPrimary: true,
+            isGenerated: true,
+            generationStrategy: 'increment',
+          },
+          {
+            name: 'userId',
+            type: 'int',
+            isNullable: true,
+          },
+          {
+            name: 'targetWordId',
+            type: 'varchar',
+            length: '36',
+          },
+          {
+            name: 'guessHistory',
+            type: 'json',
+            default: "'[]'",
+          },
+          {
+            name: 'isCompleted',
+            type: 'boolean',
+            default: false,
+          },
+          {
+            name: 'isWon',
+            type: 'boolean',
+            default: false,
+          },
+          {
+            name: 'attemptsRemaining',
+            type: 'int',
+            default: 6,
+          },
+          {
+            name: 'completedAt',
+            type: 'timestamp',
+            isNullable: true,
+          },
+          {
+            name: 'createdAt',
+            type: 'timestamp',
+            default: 'CURRENT_TIMESTAMP',
+          },
+          {
+            name: 'updatedAt',
+            type: 'timestamp',
+            default: 'CURRENT_TIMESTAMP',
+            onUpdate: 'CURRENT_TIMESTAMP',
+          },
+        ],
+        foreignKeys: [
+          {
+            columnNames: ['userId'],
+            referencedTableName: 'users',
+            referencedColumnNames: ['id'],
+            onDelete: 'SET NULL',
+          },
+          {
+            columnNames: ['targetWordId'],
+            referencedTableName: 'words',
+            referencedColumnNames: ['id'],
+            onDelete: 'CASCADE',
+          },
+        ],
+        indices: [
+          {
+            name: 'IDX_wordle_sessions_user_id',
+            columnNames: ['userId'],
+          },
+          {
+            name: 'IDX_wordle_sessions_target_word_id',
+            columnNames: ['targetWordId'],
+          },
+          {
+            name: 'IDX_wordle_sessions_is_completed',
+            columnNames: ['isCompleted'],
+          },
+          {
+            name: 'IDX_wordle_sessions_created_at',
+            columnNames: ['createdAt'],
+          },
+        ],
+      }),
+      true,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.dropTable('wordle_sessions');
+  }
+}


### PR DESCRIPTION
# Add Word Validation to Wordle Guess Endpoint

Closes #518 

## Overview
This PR implements comprehensive word validation for the Wordle game by rejecting guesses that are not valid dictionary words. This ensures a fair and standard game experience by preventing players from submitting random, non-existent words like "AAAAA".

## Changes Made

### Core Implementation
- **DictionaryService**: New service that loads and manages the official word list from `five-letter-words.txt`
- **Word Validation**: Integrated validation into the guess submission pipeline before game engine evaluation
- **Error Handling**: Returns proper `400 Bad Request` with message "Not in word list" for invalid words

### Key Features
- Loads 2,746 valid 5-letter words from the existing dictionary file
- Case-insensitive word validation (accepts "audio", "AUDIO", "Audio")
- Validates words before any game logic checks (session state, attempts remaining)
- Invalid word submissions do not count as attempts and are not saved to guess history
- Maintains all existing functionality for valid words

## API Changes

### Modified Endpoint
**POST /wordle-sessions/:id/guess**

**New Error Response:**
```json
{
  "statusCode": 400,
  "message": "Not in word list",
  "error": "Bad Request"
}
```

**Validation Order:**
1. Word length validation (5 letters)
2. **Dictionary validation (NEW)** - "Not in word list"
3. Session completion check
4. Attempts remaining check
5. Game engine evaluation

## Technical Implementation

### DictionaryService
- Loads words from `backend/data/five-letter-words.txt` on module initialization
- Filters and normalizes words to uppercase 5-letter format
- Provides `isValidWord(word: string): boolean` method
- Includes comprehensive error handling for file loading issues

### Service Integration
- Added `DictionaryService` to `WordleSessionModule` providers
- Injected into `WordleSessionService` constructor
- Validation occurs immediately after basic format checks

## Screencast for tests: 

https://github.com/user-attachments/assets/b75e926a-5a53-4925-867c-4a518b0b70e8



## Testing

### Comprehensive Test Coverage
- **DictionaryService**: 11/11 tests passing
  - Dictionary loading and error handling
  - Case-insensitive validation
  - Word filtering and statistics
  
- **WordleSessionService**: 11/11 tests passing
  - Integration with dictionary validation
  - Error handling for invalid words
  - Maintains all existing functionality
  
- **WordleSessionController**: 9/9 tests passing
  - API error response handling
  - Error propagation from service layer
  
- **Integration Tests**: 10/10 tests passing
  - End-to-end validation workflow
  - Validation order verification
  - Edge case handling

### Test Scenarios Covered
- Valid words accepted normally
- Invalid words rejected with proper error message
- Case-insensitive validation (AUDIO, audio, Audio all work)
- Validation occurs before game state checks
- Invalid words don't consume attempts or save to history
- Whitespace handling in word input

### No Breaking Changes
- Existing valid word functionality unchanged
- All existing tests continue to pass
- API contract maintained for valid requests
- Only adds new validation layer

## Files Changed
- `src/dewordle/dictionary.service.ts` - New dictionary management service
- `src/dewordle/dictionary.service.spec.ts` - Unit tests for dictionary service
- `src/dewordle/word-validation.integration.spec.ts` - Integration tests
- `src/dewordle/wordle-session.service.ts` - Added word validation
- `src/dewordle/wordle-session.service.spec.ts` - Updated tests with validation
- `src/dewordle/wordle-session.module.ts` - Added dictionary service provider
- `src/dewordle/wordle-session.controller.spec.ts` - Added validation error test

## Acceptance Criteria Verification
POST /wordle-sessions/:id/guess endpoint validates against dictionary  
Validation occurs before game engine evaluation  
Returns 400 Bad Request with "Not in word list" message for invalid words  
Invalid words do not count as attempts or save to guess history  
Uses existing dictionary file (`five-letter-words.txt`)

## Deployment Notes
- No database migrations required
- No environment variable changes needed
- Dictionary file already exists in the project
- Zero downtime deployment - only adds validation layer

## Future Enhancements
- Cache dictionary in Redis for distributed deployments
- Add metrics for invalid word attempt tracking
- Consider custom word lists for different difficulty levels
- Implement word suggestion API for near-matches

---
