### PR TITLE
fix: resolve Wave 5 Phase 3B issues #613 #614 #615 #616

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,27 @@ permissions:
   contents: read
 
 jobs:
+  lockfile-guard:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Check frontend lockfile is in sync with package.json
+        run: |
+          if git diff --name-only HEAD~1 HEAD 2>/dev/null | grep -q "^frontend/package\.json$"; then
+            if ! git diff --name-only HEAD~1 HEAD 2>/dev/null | grep -q "^frontend/package-lock\.json$"; then
+              echo "ERROR: frontend/package.json was changed but frontend/package-lock.json was not updated."
+              exit 1
+            fi
+          fi
+      - name: Check backend lockfile is in sync with package.json
+        run: |
+          if git diff --name-only HEAD~1 HEAD 2>/dev/null | grep -q "^backend/package\.json$"; then
+            if ! git diff --name-only HEAD~1 HEAD 2>/dev/null | grep -q "^backend/package-lock\.json$"; then
+              echo "ERROR: backend/package.json was changed but backend/package-lock.json was not updated."
+              exit 1
+            fi
+          fi
+
   backend:
     runs-on: ubuntu-latest
     timeout-minutes: 20

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -7,6 +7,21 @@
 4. Run local quality checks.
 5. Open PR using template.
 
+## Lockfile Freshness Guard
+
+CI enforces that `package-lock.json` is updated whenever `package.json` changes.
+
+**Rule:** If `frontend/package.json` or `backend/package.json` is modified in a PR, the corresponding `package-lock.json` must also be updated in the same commit.
+
+**How to comply:**
+```bash
+# After changing package.json in frontend or backend, regenerate the lockfile:
+cd frontend && npm install   # updates frontend/package-lock.json
+cd backend  && npm install   # updates backend/package-lock.json
+```
+
+If CI fails with `ERROR: package.json was changed but package-lock.json was not updated`, run the command above and amend your commit.
+
 ## Backend Notes
 - API prefix: `/api/v1`
 - Swagger: `/api`

--- a/docs/REPLAY_SAFETY_MODEL.md
+++ b/docs/REPLAY_SAFETY_MODEL.md
@@ -1,0 +1,94 @@
+# Replay Safety Model: Contract → SDK → Indexer Pipeline
+
+This document describes the end-to-end replay safety narrative and operational checklist for the DeWordle Soroban migration pipeline, covering the Smart Contract (SC), TypeScript SDK, and Backend Indexer (BE) layers.
+
+## Source Anchors
+
+This document consolidates safety invariants established in:
+- **#577** — Soroban contract session and nonce model
+- **#583** — TypeScript SDK transaction lifecycle
+- **#593** — Backend indexer event ingestion and projection
+
+---
+
+## Layer-by-Layer Safety Model
+
+### 1. Smart Contract (SC) Layer
+
+**Nonce invariant:** Each player action is keyed by `(player, nonce)`. The contract rejects any submission where the nonce has already been consumed, preventing duplicate guess or finalize transactions.
+
+**Event-order invariant:** Contract events are emitted in strict ledger sequence. The event index within a transaction is deterministic and monotonically increasing.
+
+**State-transition guard:** A session in `InProgress` state cannot be finalized twice. Invalid transitions are rejected at the contract level before any event is emitted.
+
+**Empty commitment guard:** Commitments with empty or zero-value payloads are rejected to prevent placeholder-guess replay attacks.
+
+### 2. TypeScript SDK Layer
+
+**Transaction lifecycle states:** The SDK tracks each transaction through explicit states: `idle → signing → submitting → success | error`. A transaction that errors does not silently retry; the caller must explicitly resubmit.
+
+**Signing abstraction:** Freighter signing is separated from submission logic. A signed-but-not-submitted transaction cannot be replayed by the SDK automatically.
+
+**Network config guard:** Network configuration (RPC URL, passphrase, contract ID) is centralized. Misconfigured submissions are caught at SDK initialization, not at submission time.
+
+### 3. Backend Indexer (BE) Layer
+
+**Unique ingestion key:** Every ingested event is stored with a composite unique key `(network, txHash, eventIndex)`. Duplicate event delivery from the Soroban RPC poller is silently deduplicated via upsert — the projection is not applied twice.
+
+**Idempotent projections:** `ProjectionService` updates are designed to be idempotent. Replaying the same event sequence produces the same read-model state.
+
+**Cursor checkpoint model:** The indexer persists a durable cursor (ledger sequence + event index) after each successful batch. On restart, polling resumes from the last checkpoint, preventing both gaps and double-processing.
+
+---
+
+## Cross-Layer Invariants
+
+| Invariant | SC | SDK | BE |
+|-----------|:--:|:---:|:--:|
+| Nonce uniqueness per player | ✓ enforced | ✓ tracked | ✓ deduplicated |
+| Event order determinism | ✓ ledger-ordered | ✓ submitted once | ✓ cursor-ordered |
+| Idempotent processing | ✓ state guards | ✓ explicit lifecycle | ✓ upsert + idempotent projections |
+| No silent retry on error | ✓ tx rejected | ✓ error state surfaced | ✓ checkpoint not advanced |
+
+---
+
+## Operational Checklist
+
+### Pre-deployment
+
+- [ ] Confirm contract nonce table is initialized (no stale nonces from prior deployment)
+- [ ] Confirm SDK network config points to correct RPC endpoint and contract ID
+- [ ] Confirm indexer cursor table is empty or reset for a fresh network
+
+### Post-deployment validation
+
+```bash
+# 1. Verify backend indexer is running and cursor is advancing
+curl http://localhost:3000/indexer/status
+
+# 2. Submit a test session via SDK and confirm event appears in projection
+# (replace with actual test script)
+npx ts-node scripts/test-session-replay.ts
+
+# 3. Replay the same event twice and confirm projection count does not increase
+# Expected: idempotent — second replay produces no change
+npx ts-node scripts/test-replay-idempotency.ts
+```
+
+### Incident response
+
+- [ ] If duplicate events are detected in projections: check `IngestedEventEntity` for missing unique constraint on `(network, txHash, eventIndex)`
+- [ ] If cursor regresses: check checkpoint write path in `EventProcessorService` — ensure checkpoint is written *after* projection commit, not before
+- [ ] If nonce collision is reported: verify contract storage is not shared across networks (testnet vs mainnet isolation)
+
+---
+
+## ADR Compatibility
+
+This model is consistent with **ADR 0001** (event-sourced projection architecture). No invariant described here contradicts the append-only event log assumption in ADR 0001. Maintainer review should confirm no new state-mutation paths have been introduced outside the event processor.
+
+## Related Docs
+
+- [Security Foundation](./SECURITY_FOUNDATION.md)
+- [Backend Indexer Foundation](./BACKEND_INDEXER_FOUNDATION.md)
+- [Soroban Foundation Architecture](./SOROBAN_FOUNDATION_ARCHITECTURE.md)

--- a/docs/WAVE_CONTRIBUTOR_QUICKSTART.md
+++ b/docs/WAVE_CONTRIBUTOR_QUICKSTART.md
@@ -1,0 +1,93 @@
+# Wave Contributor Quickstart
+
+Welcome to the DeWordle Wave 5 contributor program. This page maps you to the right setup, commands, and first tasks based on your track.
+
+## Prerequisites (all tracks)
+
+```bash
+# Clone the repo
+git clone https://github.com/kike-alt/DeWordle.git
+cd DeWordle
+
+# Install all JS dependencies
+npm run install:all
+```
+
+---
+
+## Track Quickstart Matrix
+
+| Track | Setup | First Validation | First Task |
+|-------|-------|-----------------|------------|
+| **DEVOPS** | See below | `npm run verify:backend` | Add/improve a CI job in `.github/workflows/ci.yml` |
+| **DOCS** | No extra setup | Read `docs/ARCHITECTURE.md` | Improve or add a doc in `docs/` |
+| **DX** | See below | `npm run verify:frontend` | Improve contributor ergonomics in `README.md` or `docs/` |
+| **QA** | See below | `npm run verify:backend && npm run verify:frontend` | Add a test in `backend/` or `frontend/` |
+| **AI/AUTOMATION** | See below | Run `scripts/gen-rc-checklist.sh M5` | Improve or add a script in `scripts/` |
+
+---
+
+## Track Setup Commands
+
+### DEVOPS / DX / QA
+
+```bash
+# Frontend
+cd frontend && npm ci
+npm run lint
+npm run typecheck
+npm run build
+
+# Backend
+cd backend && npm ci
+npm run lint
+npm run typecheck
+npm run test -- --runInBand
+```
+
+### AI/AUTOMATION
+
+```bash
+# Requires gh CLI authenticated
+gh auth status
+
+# Generate a release-candidate checklist
+./scripts/gen-rc-checklist.sh M5
+```
+
+### Soroban (all tracks touching onchain code)
+
+```bash
+cd soroban
+cargo check --workspace
+```
+
+---
+
+## Validation Shortcuts
+
+```bash
+npm run verify:frontend   # lint + typecheck + build
+npm run verify:backend    # lint + typecheck + test
+```
+
+---
+
+## Key Architecture Docs
+
+- [Architecture Overview](./ARCHITECTURE.md)
+- [Soroban Foundation Architecture](./SOROBAN_FOUNDATION_ARCHITECTURE.md)
+- [Backend Indexer Foundation](./BACKEND_INDEXER_FOUNDATION.md)
+- [Frontend Wallet Foundation](./FRONTEND_WALLET_FOUNDATION.md)
+- [Security Foundation](./SECURITY_FOUNDATION.md)
+- [Wave 5 Execution Plan](./wave/WAVE5_EXECUTION_PLAN.md)
+- [Wave 5 Issue Tracks](./wave/WAVE5_ISSUE_TRACKS.md)
+
+---
+
+## Finding Your First Issue
+
+1. Go to [Issues](https://github.com/kike-alt/DeWordle/issues)
+2. Filter by your track label (e.g. `track:DEVOPS`, `track:DOCS`, `track:DX`, `track:QA`, `track:AI/AUTOMATION`)
+3. Pick a `difficulty:beginner` issue
+4. Comment to claim it, then open a PR referencing the issue number (`Closes #NNN`)

--- a/scripts/gen-rc-checklist.sh
+++ b/scripts/gen-rc-checklist.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# gen-rc-checklist.sh
+# Generates a markdown release-candidate checklist from open GitHub issues
+# for a given milestone (M5 or M6).
+#
+# Usage: ./scripts/gen-rc-checklist.sh <milestone> [repo]
+#   milestone  M5 or M6
+#   repo       owner/repo  (default: kike-alt/DeWordle)
+#
+# Requires: gh CLI authenticated
+
+set -euo pipefail
+
+MILESTONE="${1:-M5}"
+REPO="${2:-kike-alt/DeWordle}"
+OUTPUT="docs/wave/RC_CHECKLIST_${MILESTONE}.md"
+
+# Validate milestone
+if [[ "$MILESTONE" != "M5" && "$MILESTONE" != "M6" ]]; then
+  echo "ERROR: milestone must be M5 or M6, got '$MILESTONE'" >&2
+  exit 1
+fi
+
+echo "Fetching open issues for milestone $MILESTONE from $REPO..."
+
+# Fetch open issues for the milestone
+ISSUES=$(gh issue list \
+  --repo "$REPO" \
+  --milestone "$MILESTONE" \
+  --state open \
+  --json number,title,labels,assignees \
+  --limit 200)
+
+ISSUE_COUNT=$(echo "$ISSUES" | jq 'length')
+
+# Build markdown
+{
+  echo "# Release Candidate Checklist — $MILESTONE"
+  echo ""
+  echo "> Generated: $(date -u '+%Y-%m-%dT%H:%M:%SZ')"
+  echo "> Repo: $REPO | Milestone: $MILESTONE | Open issues: $ISSUE_COUNT"
+  echo ""
+  echo "## Open Issues"
+  echo ""
+
+  if [[ "$ISSUE_COUNT" -eq 0 ]]; then
+    echo "_No open issues — milestone is complete._"
+  else
+    echo "$ISSUES" | jq -r '.[] |
+      "- [ ] #\(.number) \(.title)" +
+      (if (.labels | length) > 0 then " `" + ([.labels[].name] | join("` `")) + "`" else "" end)'
+  fi
+
+  echo ""
+  echo "## Critical Labels Summary"
+  echo ""
+  echo "$ISSUES" | jq -r '
+    [.[].labels[].name] | group_by(.) | map({label: .[0], count: length}) |
+    sort_by(-.count) | .[] |
+    "- **\(.label)**: \(.count) open issue(s)"
+  '
+
+  echo ""
+  echo "## Validation Commands"
+  echo ""
+  echo '```bash'
+  echo "# Verify frontend build"
+  echo "npm run verify:frontend"
+  echo ""
+  echo "# Verify backend build"
+  echo "npm run verify:backend"
+  echo ""
+  echo "# Check Soroban workspace"
+  echo "cd soroban && cargo check --workspace"
+  echo '```'
+} > "$OUTPUT"
+
+echo "Checklist written to $OUTPUT"


### PR DESCRIPTION
## Summary

Resolves all four Wave 5 Phase 3B issues assigned to @Tyler7x.

---

### #613 — Lockfile freshness guard for frontend/backend package manifests

- Added a `lockfile-guard` job to `.github/workflows/ci.yml` that fails CI when `package.json` is changed without a corresponding `package-lock.json` update (checked for both `frontend/` and `backend/`).
- Failure message identifies the exact file mismatch.
- Guard documented in `docs/DEVELOPMENT.md`.

Closes #613

---

### #614 — Release-candidate checklist automation for migration phases

- Added `scripts/gen-rc-checklist.sh`: a bash script that queries open GitHub issues for a given milestone (M5 or M6) via `gh` CLI and writes a markdown checklist artifact to `docs/wave/RC_CHECKLIST_<MILESTONE>.md`.
- Supports M5 and M6 milestones; includes label summary and validation commands.

Closes #614

---

### #615 — Wave contributor quickstart path by track

- Added `docs/WAVE_CONTRIBUTOR_QUICKSTART.md`: a single-page quickstart mapping contributors to track-specific setup commands and first tasks for DEVOPS, DOCS, DX, QA, and AI/AUTOMATION tracks.
- Links to existing architecture docs; includes a command matrix for local validation.

Closes #615

---

### #616 — Document replay safety model from contract to indexer pipeline

- Added `docs/REPLAY_SAFETY_MODEL.md`: end-to-end replay safety narrative covering nonce, cursor, and event-order invariants across SC→SDK→BE layers.
- References #577, #583, #593 as source anchors.
- Includes cross-layer invariant table, operational checklist, and validation commands.
- Confirmed no contradiction with ADR 0001.

Closes #616

---

## Testing

- CI lockfile guard: logic verified against `git diff` output format.
- RC checklist script: dry-run tested with `gh issue list` output.
- Docs: reviewed against existing `SECURITY_FOUNDATION.md` and `BACKEND_INDEXER_FOUNDATION.md` for consistency.