### PR TITLE
feat(indexer): add getLagSnapshot endpoint and corresponding service …

### DIFF
--- a/backend/src/indexer/dto/indexer-lag-response.dto.ts
+++ b/backend/src/indexer/dto/indexer-lag-response.dto.ts
@@ -1,0 +1,92 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+
+export class IndexerCursorSnapshotDto {
+  @ApiProperty({
+    description: 'Most recently checkpointed ledger for this stream.',
+    example: 248120,
+  })
+  lastLedger: number;
+
+  @ApiProperty({
+    description: 'Last processed transaction hash stored in the cursor.',
+    example: '7f0c8a32b6f4d10d2a9ecb90df7c8f4af1cfc9890c17cdb7d07af01d9b83f1c2',
+  })
+  lastTxHash: string;
+
+  @ApiProperty({
+    description: 'Last processed contract event index within the transaction.',
+    example: 2,
+  })
+  lastEventIndex: number;
+
+  @ApiPropertyOptional({
+    description: 'Timestamp of the latest cursor checkpoint update.',
+    example: '2026-05-29T12:34:56.000Z',
+  })
+  updatedAt?: Date;
+}
+
+export class IndexerLagResponseDto {
+  @ApiProperty({
+    description: 'Network currently being indexed.',
+    example: 'testnet',
+  })
+  network: string;
+
+  @ApiProperty({
+    description: 'Logical stream key for the cursor snapshot.',
+    example: 'core_game_events',
+  })
+  streamKey: string;
+
+  @ApiProperty({
+    description: 'Checkpointed cursor snapshot for the indexed stream.',
+    type: IndexerCursorSnapshotDto,
+  })
+  cursor: IndexerCursorSnapshotDto;
+
+  @ApiProperty({
+    description: 'Convenience field mirroring cursor.lastTxHash for dashboards.',
+    example: '7f0c8a32b6f4d10d2a9ecb90df7c8f4af1cfc9890c17cdb7d07af01d9b83f1c2',
+  })
+  lastProcessedTxHash: string;
+
+  @ApiPropertyOptional({
+    description: 'Latest ledger sequence reported by Soroban RPC for the configured network.',
+    example: 248145,
+    nullable: true,
+  })
+  networkLatestLedger: number | null;
+
+  @ApiPropertyOptional({
+    description:
+      'Derived ledger lag between the network latest ledger and the cursor ledger. Null when the RPC snapshot is unavailable.',
+    example: 25,
+    nullable: true,
+  })
+  lagLedgers: number | null;
+
+  @ApiProperty({
+    description: 'Number of replayed events skipped by the indexer.',
+    example: 3,
+  })
+  replaySkips: number;
+
+  @ApiProperty({
+    description: 'Total events successfully ingested by the current process.',
+    example: 1200,
+  })
+  ingestedTotal: number;
+
+  @ApiProperty({
+    description: 'Total projection errors observed by the current process.',
+    example: 1,
+  })
+  projectionErrors: number;
+
+  @ApiProperty({
+    description: 'Total poll cycles executed by the current process.',
+    example: 44,
+  })
+  pollCycles: number;
+}

--- a/backend/src/indexer/indexer.controller.spec.ts
+++ b/backend/src/indexer/indexer.controller.spec.ts
@@ -1,0 +1,75 @@
+import { INestApplication } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import * as request from 'supertest';
+import { IndexerController } from './indexer.controller';
+import { IndexerService } from './indexer.service';
+
+describe('IndexerController (Integration Tests)', () => {
+  let app: INestApplication;
+  let indexerService: { ingest: jest.Mock; getLagSnapshot: jest.Mock };
+
+  beforeEach(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      controllers: [IndexerController],
+      providers: [
+        {
+          provide: IndexerService,
+          useValue: {
+            ingest: jest.fn(),
+            getLagSnapshot: jest.fn(),
+          },
+        },
+      ],
+    }).compile();
+
+    app = moduleFixture.createNestApplication();
+    await app.init();
+
+    indexerService = moduleFixture.get(IndexerService);
+  });
+
+  afterEach(async () => {
+    await app.close();
+  });
+
+  it('/indexer/lag (GET) returns the lag snapshot schema and values', async () => {
+    indexerService.getLagSnapshot.mockResolvedValue({
+      network: 'testnet',
+      streamKey: 'core_game_events',
+      cursor: {
+        lastLedger: 120,
+        lastTxHash: 'tx-abc',
+        lastEventIndex: 4,
+        updatedAt: '2026-05-29T12:34:56.000Z',
+      },
+      lastProcessedTxHash: 'tx-abc',
+      networkLatestLedger: 125,
+      lagLedgers: 5,
+      replaySkips: 2,
+      ingestedTotal: 33,
+      projectionErrors: 1,
+      pollCycles: 8,
+    });
+
+    await request(app.getHttpServer())
+      .get('/indexer/lag')
+      .expect(200)
+      .expect({
+        network: 'testnet',
+        streamKey: 'core_game_events',
+        cursor: {
+          lastLedger: 120,
+          lastTxHash: 'tx-abc',
+          lastEventIndex: 4,
+          updatedAt: '2026-05-29T12:34:56.000Z',
+        },
+        lastProcessedTxHash: 'tx-abc',
+        networkLatestLedger: 125,
+        lagLedgers: 5,
+        replaySkips: 2,
+        ingestedTotal: 33,
+        projectionErrors: 1,
+        pollCycles: 8,
+      });
+  });
+});

--- a/backend/src/indexer/indexer.controller.ts
+++ b/backend/src/indexer/indexer.controller.ts
@@ -1,10 +1,34 @@
-import { Body, Controller, Post, UsePipes, ValidationPipe } from '@nestjs/common';
+import {
+  Body,
+  Controller,
+  Get,
+  Post,
+  UsePipes,
+  ValidationPipe,
+} from '@nestjs/common';
+import { ApiOkResponse, ApiOperation, ApiTags } from '@nestjs/swagger';
 import { IndexerService } from './indexer.service';
 import { IngestedEventDto } from './dto/ingested-event.dto';
+import { IndexerLagResponseDto } from './dto/indexer-lag-response.dto';
 
+@ApiTags('Indexer')
 @Controller('indexer')
 export class IndexerController {
   constructor(private readonly indexerService: IndexerService) {}
+
+  @Get('lag')
+  @ApiOperation({
+    summary: 'Get indexer lag snapshot',
+    description:
+      'Returns the current stream cursor position, latest known network ledger, derived lag, and replay skip counters for operational dashboards.',
+  })
+  @ApiOkResponse({
+    description: 'Indexer lag snapshot for operational monitoring dashboards.',
+    type: IndexerLagResponseDto,
+  })
+  async getLag() {
+    return this.indexerService.getLagSnapshot();
+  }
 
   @Post('ingest')
   @UsePipes(new ValidationPipe({ whitelist: true, forbidNonWhitelisted: false, transform: true }))

--- a/backend/src/indexer/indexer.service.spec.ts
+++ b/backend/src/indexer/indexer.service.spec.ts
@@ -9,6 +9,7 @@ const makeCursor = (lastLedger = 0) => ({
   lastLedger,
   lastTxHash: '',
   lastEventIndex: 0,
+  updatedAt: new Date('2026-05-29T12:34:56.000Z'),
 });
 
 const makeService = (overrides: {
@@ -42,6 +43,47 @@ const makeService = (overrides: {
 
   return { svc, cursorService, eventProcessor };
 };
+
+describe('IndexerService.getLagSnapshot', () => {
+  it('returns cursor snapshot, replay counters, and derived lag fields', async () => {
+    const { svc } = makeService({ rpcUrl: 'http://rpc', network: 'mainnet', cursorLedger: 40 });
+    svc.metrics.replaySkips = 3;
+    svc.metrics.ingestedTotal = 12;
+    svc.metrics.projectionErrors = 1;
+    svc.metrics.pollCycles = 7;
+
+    jest.spyOn(svc, 'fetchLatestLedger').mockResolvedValue(52);
+
+    await expect(svc.getLagSnapshot()).resolves.toEqual({
+      network: 'mainnet',
+      streamKey: INDEXER_STREAM_CORE_GAME,
+      cursor: {
+        lastLedger: 40,
+        lastTxHash: '',
+        lastEventIndex: 0,
+        updatedAt: new Date('2026-05-29T12:34:56.000Z'),
+      },
+      lastProcessedTxHash: '',
+      networkLatestLedger: 52,
+      lagLedgers: 12,
+      replaySkips: 3,
+      ingestedTotal: 12,
+      projectionErrors: 1,
+      pollCycles: 7,
+    });
+  });
+
+  it('returns null lag fields when RPC URL is not configured', async () => {
+    const { svc } = makeService({ rpcUrl: '', network: 'testnet', cursorLedger: 9 });
+    const latestLedgerSpy = jest.spyOn(svc, 'fetchLatestLedger');
+
+    const snapshot = await svc.getLagSnapshot();
+
+    expect(snapshot.networkLatestLedger).toBeNull();
+    expect(snapshot.lagLedgers).toBeNull();
+    expect(latestLedgerSpy).not.toHaveBeenCalled();
+  });
+});
 
 describe('IndexerService.poll', () => {
   it('returns 0 and warns when RPC env vars are missing', async () => {

--- a/backend/src/indexer/indexer.service.ts
+++ b/backend/src/indexer/indexer.service.ts
@@ -1,5 +1,6 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
+import axios from 'axios';
 import { IngestedEventDto } from './dto/ingested-event.dto';
 import { EventProcessorService } from './processors/event-processor.service';
 import { EventNormalizerService } from './processors/event-normalizer.service';
@@ -14,6 +15,24 @@ export interface IndexerMetrics {
   projectionErrors: number;
   pollCycles: number;
   lastCursorLedger: number;
+}
+
+export interface IndexerLagSnapshot {
+  network: string;
+  streamKey: string;
+  cursor: {
+    lastLedger: number;
+    lastTxHash: string;
+    lastEventIndex: number;
+    updatedAt?: Date;
+  };
+  lastProcessedTxHash: string;
+  networkLatestLedger: number | null;
+  lagLedgers: number | null;
+  replaySkips: number;
+  ingestedTotal: number;
+  projectionErrors: number;
+  pollCycles: number;
 }
 
 @Injectable()
@@ -66,6 +85,38 @@ export class IndexerService {
       });
       throw err;
     }
+  }
+
+  async getLagSnapshot(): Promise<IndexerLagSnapshot> {
+    const network =
+      (this.configService.get<string>('SOROBAN_NETWORK') as 'testnet' | 'mainnet') ||
+      'testnet';
+    const rpcUrl = this.configService.get<string>('SOROBAN_RPC_URL');
+    const cursor = await this.cursorService.getOrCreate(network, INDEXER_STREAM_CORE_GAME);
+
+    let networkLatestLedger: number | null = null;
+    if (rpcUrl) {
+      networkLatestLedger = await this.fetchLatestLedger(rpcUrl);
+    }
+
+    return {
+      network,
+      streamKey: INDEXER_STREAM_CORE_GAME,
+      cursor: {
+        lastLedger: cursor.lastLedger,
+        lastTxHash: cursor.lastTxHash,
+        lastEventIndex: cursor.lastEventIndex,
+        updatedAt: cursor.updatedAt,
+      },
+      lastProcessedTxHash: cursor.lastTxHash,
+      networkLatestLedger,
+      lagLedgers:
+        networkLatestLedger === null ? null : Math.max(networkLatestLedger - cursor.lastLedger, 0),
+      replaySkips: this.metrics.replaySkips,
+      ingestedTotal: this.metrics.ingestedTotal,
+      projectionErrors: this.metrics.projectionErrors,
+      pollCycles: this.metrics.pollCycles,
+    };
   }
 
   async poll(): Promise<number> {
@@ -121,7 +172,6 @@ export class IndexerService {
     contractId: string,
     afterLedger: number,
   ): Promise<Record<string, unknown>[]> {
-    const { default: axios } = await import('axios');
     const body = {
       jsonrpc: '2.0',
       id: 1,
@@ -138,6 +188,22 @@ export class IndexerService {
     }>(rpcUrl, body, { timeout: 10_000 });
 
     return response.data?.result?.events ?? [];
+  }
+
+  async fetchLatestLedger(rpcUrl: string): Promise<number> {
+    const response = await axios.post<{
+      result?: { latestLedger?: number };
+    }>(
+      rpcUrl,
+      {
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'getHealth',
+      },
+      { timeout: 10_000 },
+    );
+
+    return response.data?.result?.latestLedger ?? 0;
   }
 
   recordReplaySkip(ledger: number, txHash: string, eventIndex: number) {


### PR DESCRIPTION
## Summary
Adds an operational monitoring endpoint for indexer lag.

## Changes
- Added `GET /indexer/lag` in `backend/src/indexer/indexer.controller.ts`
- Added `getLagSnapshot()` in `backend/src/indexer/indexer.service.ts`
- Added documented response schema in `backend/src/indexer/dto/indexer-lag-response.dto.ts`
- Added tests for service lag calculation and endpoint response shape

## Response Includes
- network + stream cursor snapshot
- last processed tx hash
- latest network ledger
- derived ledger lag
- replay skip / ingest / error / poll counters

## Validation
- Added endpoint integration test for schema + values
- Added service test for lag calculation behavior

## Notes
- Did not address unrelated pre-existing backend/test environment issues
- Local test execution is blocked in this workspace because `jest` is not installed


closes #638 