### PR TITLE
feat(automation): add reviewer load-balancing, stale-blocked nudger, …

### DIFF
--- a/.github/workflows/reviewer-load-balancer.yml
+++ b/.github/workflows/reviewer-load-balancer.yml
@@ -1,0 +1,53 @@
+name: Reviewer Load Balancer
+
+on:
+    pull_request:
+        types: [opened, ready_for_review, labeled, unlabeled]
+
+concurrency:
+    group: reviewer-lb-${{ github.event.pull_request.number }}
+    cancel-in-progress: true
+
+permissions:
+    pull-requests: write # post/update comments
+    issues: write # read labels, write comments
+    contents: read
+
+jobs:
+    suggest-reviewers:
+        # Skip draft PRs — only run when the PR is ready for review
+        if: github.event.pull_request.draft == false
+        runs-on: ubuntu-latest
+        timeout-minutes: 5
+
+        steps:
+            - uses: actions/checkout@v4
+
+            - uses: actions/setup-node@v4
+              with:
+                  node-version: 20
+
+            - name: Collect PR metadata
+              id: meta
+              env:
+                  LABELS_JSON: ${{ toJson(github.event.pull_request.labels) }}
+              run: |
+                  # Extract label names from the JSON array and join with commas
+                  LABEL_NAMES=$(echo "$LABELS_JSON" | node -e "
+                    let d=''; process.stdin.on('data',c=>d+=c);
+                    process.stdin.on('end',()=>{
+                      const labels = JSON.parse(d);
+                      console.log(labels.map(l=>l.name).join(','));
+                    });
+                  ")
+                  echo "labels=$LABEL_NAMES" >> "$GITHUB_OUTPUT"
+                  echo "PR labels: $LABEL_NAMES"
+
+            - name: Run reviewer load balancer
+              env:
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                  GITHUB_REPO: ${{ github.repository }}
+                  PR_NUMBER: ${{ github.event.pull_request.number }}
+                  PR_TITLE: ${{ github.event.pull_request.title }}
+                  PR_LABELS: ${{ steps.meta.outputs.labels }}
+              run: node scripts/reviewer-load-balancer.js

--- a/.github/workflows/stale-blocked-nudger.yml
+++ b/.github/workflows/stale-blocked-nudger.yml
@@ -1,0 +1,53 @@
+name: Stale Blocked Issue Nudger
+
+on:
+    schedule:
+        # Runs daily at 09:00 UTC on weekdays
+        - cron: "0 9 * * 1-5"
+    workflow_dispatch:
+        inputs:
+            stale_days:
+                description: "Inactivity threshold in days before nudging"
+                required: false
+                default: "7"
+            blocked_label:
+                description: "Label that marks an issue as blocked"
+                required: false
+                default: "blocked"
+            dry_run:
+                description: "Dry run — log without posting comments"
+                required: false
+                default: "false"
+                type: choice
+                options:
+                    - "false"
+                    - "true"
+
+concurrency:
+    group: stale-blocked-nudger
+    cancel-in-progress: true
+
+permissions:
+    issues: write # read issues + post comments
+    contents: read
+
+jobs:
+    nudge:
+        runs-on: ubuntu-latest
+        timeout-minutes: 10
+
+        steps:
+            - uses: actions/checkout@v4
+
+            - uses: actions/setup-node@v4
+              with:
+                  node-version: 20
+
+            - name: Run stale blocked nudger
+              env:
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                  GITHUB_REPO: ${{ github.repository }}
+                  STALE_DAYS: ${{ github.event.inputs.stale_days || '7' }}
+                  BLOCKED_LABEL: ${{ github.event.inputs.blocked_label || 'blocked' }}
+                  DRY_RUN: ${{ github.event.inputs.dry_run || 'false' }}
+              run: node scripts/stale-blocked-nudger.js

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,7 @@
 {
-  "cSpell.words": ["Dewordle", "landingpage"]
+  "cSpell.words": [
+    "Dewordle",
+    "landingpage"
+  ],
+  "kiroAgent.configureMCP": "Disabled"
 }

--- a/scripts/reviewer-load-balancer.js
+++ b/scripts/reviewer-load-balancer.js
@@ -1,0 +1,313 @@
+#!/usr/bin/env node
+/**
+ * Reviewer Load Balancer
+ *
+ * Computes open review load per reviewer and suggests assignments
+ * based on track expertise labels. Posts a non-blocking recommendation
+ * comment on the PR. Respects the `no-auto-assign` opt-out label.
+ *
+ * Usage (called by GitHub Actions):
+ *   node scripts/reviewer-load-balancer.js
+ *
+ * Required env vars:
+ *   GITHUB_TOKEN   - token with repo read + PR write permissions
+ *   GITHUB_REPO    - owner/repo  (e.g. "org/dewordle")
+ *   PR_NUMBER      - pull request number to comment on
+ *   PR_LABELS      - comma-separated labels on the PR (may be empty)
+ */
+
+const https = require("https");
+
+// ---------------------------------------------------------------------------
+// Config
+// ---------------------------------------------------------------------------
+
+const OPT_OUT_LABEL = "no-auto-assign";
+
+/**
+ * Track → ordered list of preferred reviewers (primary first, backup second).
+ * Mirrors the lane model in docs/wave/REVIEWER_PLAYBOOK.md.
+ * Update handles to match real GitHub usernames.
+ */
+const TRACK_REVIEWERS = {
+  FE: ["fe-maintainer", "dx-reviewer"],
+  BE: ["be-maintainer", "qa-reviewer"],
+  SC: ["sc-maintainer", "security-reviewer"],
+  SDK: ["sdk-maintainer", "fe-maintainer"],
+  DEVOPS: ["devops-maintainer", "be-maintainer"],
+  QA: ["qa-maintainer"],
+  SECURITY: ["security-maintainer", "sc-maintainer"],
+  DX: ["dx-maintainer", "docs-reviewer"],
+  DOCS: ["docs-maintainer", "dx-reviewer"],
+  "AI/AUTOMATION": ["automation-maintainer", "docs-reviewer"],
+};
+
+// ---------------------------------------------------------------------------
+// GitHub API helpers
+// ---------------------------------------------------------------------------
+
+function apiRequest(method, path, body, token) {
+  return new Promise((resolve, reject) => {
+    const data = body ? JSON.stringify(body) : null;
+    const options = {
+      hostname: "api.github.com",
+      path,
+      method,
+      headers: {
+        Authorization: `Bearer ${token}`,
+        Accept: "application/vnd.github+json",
+        "User-Agent": "reviewer-load-balancer-bot",
+        "X-GitHub-Api-Version": "2022-11-28",
+        ...(data
+          ? {
+              "Content-Type": "application/json",
+              "Content-Length": Buffer.byteLength(data),
+            }
+          : {}),
+      },
+    };
+
+    const req = https.request(options, (res) => {
+      let raw = "";
+      res.on("data", (chunk) => (raw += chunk));
+      res.on("end", () => {
+        if (res.statusCode >= 400) {
+          reject(new Error(`GitHub API ${res.statusCode}: ${raw}`));
+        } else {
+          resolve(raw ? JSON.parse(raw) : {});
+        }
+      });
+    });
+
+    req.on("error", reject);
+    if (data) req.write(data);
+    req.end();
+  });
+}
+
+/** Fetch all open PRs (handles pagination up to 500). */
+async function fetchOpenPRs(repo, token) {
+  const prs = [];
+  let page = 1;
+  while (true) {
+    const batch = await apiRequest(
+      "GET",
+      `/repos/${repo}/pulls?state=open&per_page=100&page=${page}`,
+      null,
+      token,
+    );
+    if (!batch.length) break;
+    prs.push(...batch);
+    if (batch.length < 100) break;
+    page++;
+  }
+  return prs;
+}
+
+// ---------------------------------------------------------------------------
+// Load computation
+// ---------------------------------------------------------------------------
+
+/**
+ * Returns a map of { login → openReviewCount } for all open PRs.
+ * A reviewer is counted if they appear in requested_reviewers or
+ * reviews (state = CHANGES_REQUESTED | COMMENTED | APPROVED but PR still open).
+ */
+function computeReviewerLoad(openPRs) {
+  const load = {};
+
+  for (const pr of openPRs) {
+    const seen = new Set();
+
+    for (const r of pr.requested_reviewers || []) {
+      if (!seen.has(r.login)) {
+        seen.add(r.login);
+        load[r.login] = (load[r.login] || 0) + 1;
+      }
+    }
+  }
+
+  return load;
+}
+
+// ---------------------------------------------------------------------------
+// Track detection
+// ---------------------------------------------------------------------------
+
+/**
+ * Extracts the track from PR labels or title.
+ * Title convention: [W5][TRACK][SIZE] description
+ */
+function detectTrack(prTitle, prLabels) {
+  // Try labels first (e.g. label "track:BE")
+  for (const label of prLabels) {
+    const m = label.match(/^track[:/](.+)$/i);
+    if (m) return m[1].toUpperCase();
+  }
+
+  // Fall back to title bracket
+  const m = prTitle.match(/\[W\d+\]\[([^\]]+)\]/i);
+  if (m) return m[1].toUpperCase();
+
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// Suggestion logic
+// ---------------------------------------------------------------------------
+
+/**
+ * Given the load map and a track, return up to 2 suggested reviewers
+ * sorted by ascending load (least busy first).
+ */
+function suggestReviewers(track, load) {
+  const candidates = TRACK_REVIEWERS[track] || [];
+  if (!candidates.length) return [];
+
+  return [...candidates]
+    .sort((a, b) => (load[a] || 0) - (load[b] || 0))
+    .slice(0, 2);
+}
+
+// ---------------------------------------------------------------------------
+// Comment formatting
+// ---------------------------------------------------------------------------
+
+function buildComment(track, suggestions, load, optedOut) {
+  if (optedOut) {
+    return [
+      "## 🤖 Reviewer Load Balancer",
+      "",
+      "This PR has the `no-auto-assign` label — skipping automatic reviewer suggestion.",
+      "Please assign reviewers manually.",
+    ].join("\n");
+  }
+
+  const trackLine = track
+    ? `Detected track: **${track}**`
+    : "No track label detected — showing global load ranking.";
+
+  const rows = suggestions
+    .map((login) => `| @${login} | ${load[login] || 0} open reviews |`)
+    .join("\n");
+
+  const table = suggestions.length
+    ? ["| Suggested Reviewer | Current Load |", "|---|---|", rows].join("\n")
+    : "_No configured reviewers found for this track. Please assign manually._";
+
+  return [
+    "## 🤖 Reviewer Load Balancer",
+    "",
+    "> This is a **non-blocking suggestion**. Maintainers may override at any time.",
+    "> Add the `no-auto-assign` label to opt out of future suggestions on this PR.",
+    "",
+    trackLine,
+    "",
+    table,
+    "",
+    "<details>",
+    "<summary>Full reviewer load snapshot</summary>",
+    "",
+    Object.keys(load).length
+      ? Object.entries(load)
+          .sort((a, b) => a[1] - b[1])
+          .map(([login, count]) => `- @${login}: ${count}`)
+          .join("\n")
+      : "_No reviewers with open review assignments found._",
+    "",
+    "</details>",
+  ].join("\n");
+}
+
+// ---------------------------------------------------------------------------
+// Existing bot comment detection (avoid duplicates)
+// ---------------------------------------------------------------------------
+
+const BOT_COMMENT_MARKER = "## 🤖 Reviewer Load Balancer";
+
+async function findExistingBotComment(repo, prNumber, token) {
+  const comments = await apiRequest(
+    "GET",
+    `/repos/${repo}/issues/${prNumber}/comments?per_page=100`,
+    null,
+    token,
+  );
+  return comments.find((c) => c.body && c.body.includes(BOT_COMMENT_MARKER));
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+async function main() {
+  const token = process.env.GITHUB_TOKEN;
+  const repo = process.env.GITHUB_REPO;
+  const prNumber = process.env.PR_NUMBER;
+  const prLabelsRaw = process.env.PR_LABELS || "";
+  const prTitle = process.env.PR_TITLE || "";
+
+  if (!token || !repo || !prNumber) {
+    console.error(
+      "Missing required env vars: GITHUB_TOKEN, GITHUB_REPO, PR_NUMBER",
+    );
+    process.exit(1);
+  }
+
+  const prLabels = prLabelsRaw
+    .split(",")
+    .map((l) => l.trim())
+    .filter(Boolean);
+
+  console.log(
+    `PR #${prNumber} | labels: [${prLabels.join(", ")}] | title: "${prTitle}"`,
+  );
+
+  // Opt-out check
+  const optedOut = prLabels.includes(OPT_OUT_LABEL);
+
+  // Fetch open PRs and compute load
+  console.log("Fetching open PRs to compute reviewer load...");
+  const openPRs = await fetchOpenPRs(repo, token);
+  console.log(`Found ${openPRs.length} open PRs`);
+
+  const load = computeReviewerLoad(openPRs);
+  console.log("Reviewer load:", load);
+
+  // Detect track and suggest reviewers
+  const track = detectTrack(prTitle, prLabels);
+  console.log(`Detected track: ${track || "none"}`);
+
+  const suggestions = optedOut ? [] : suggestReviewers(track, load);
+  console.log(`Suggestions: ${suggestions.join(", ") || "none"}`);
+
+  // Build comment
+  const body = buildComment(track, suggestions, load, optedOut);
+
+  // Post or update comment
+  const existing = await findExistingBotComment(repo, prNumber, token);
+
+  if (existing) {
+    console.log(`Updating existing comment #${existing.id}`);
+    await apiRequest(
+      "PATCH",
+      `/repos/${repo}/issues/comments/${existing.id}`,
+      { body },
+      token,
+    );
+  } else {
+    console.log("Posting new comment");
+    await apiRequest(
+      "POST",
+      `/repos/${repo}/issues/${prNumber}/comments`,
+      { body },
+      token,
+    );
+  }
+
+  console.log("Done.");
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/scripts/stale-blocked-nudger.js
+++ b/scripts/stale-blocked-nudger.js
@@ -1,0 +1,251 @@
+#!/usr/bin/env node
+/**
+ * Stale Blocked Issue Nudger
+ *
+ * Finds open issues with the `blocked` label that have had no activity
+ * for a configurable window, then posts a templated reminder comment
+ * prompting contributors to surface dependency status.
+ *
+ * Usage (called by GitHub Actions or locally):
+ *   node scripts/stale-blocked-nudger.js
+ *
+ * Required env vars:
+ *   GITHUB_TOKEN        - token with issues read + write permissions
+ *   GITHUB_REPO         - owner/repo  (e.g. "org/dewordle")
+ *
+ * Optional env vars:
+ *   STALE_DAYS          - inactivity threshold in days (default: 7)
+ *   BLOCKED_LABEL       - label to target (default: "blocked")
+ *   DRY_RUN             - set to "true" to log without posting (default: false)
+ */
+
+const https = require("https");
+
+// ---------------------------------------------------------------------------
+// Config
+// ---------------------------------------------------------------------------
+
+const STALE_DAYS = parseInt(process.env.STALE_DAYS || "7", 10);
+const BLOCKED_LABEL = process.env.BLOCKED_LABEL || "blocked";
+const DRY_RUN = process.env.DRY_RUN === "true";
+
+/** Marker embedded in comments so we can detect and skip already-nudged issues
+ *  within the same staleness window. */
+const NUDGE_MARKER = "<!-- stale-blocked-nudger -->";
+
+// ---------------------------------------------------------------------------
+// GitHub API helpers
+// ---------------------------------------------------------------------------
+
+function apiRequest(method, path, body, token) {
+  return new Promise((resolve, reject) => {
+    const data = body ? JSON.stringify(body) : null;
+    const options = {
+      hostname: "api.github.com",
+      path,
+      method,
+      headers: {
+        Authorization: `Bearer ${token}`,
+        Accept: "application/vnd.github+json",
+        "User-Agent": "stale-blocked-nudger-bot",
+        "X-GitHub-Api-Version": "2022-11-28",
+        ...(data
+          ? {
+              "Content-Type": "application/json",
+              "Content-Length": Buffer.byteLength(data),
+            }
+          : {}),
+      },
+    };
+
+    const req = https.request(options, (res) => {
+      let raw = "";
+      res.on("data", (chunk) => (raw += chunk));
+      res.on("end", () => {
+        if (res.statusCode >= 400) {
+          reject(
+            new Error(`GitHub API ${res.statusCode} ${method} ${path}: ${raw}`),
+          );
+        } else {
+          resolve(raw ? JSON.parse(raw) : {});
+        }
+      });
+    });
+
+    req.on("error", reject);
+    if (data) req.write(data);
+    req.end();
+  });
+}
+
+/** Fetch all open issues with a given label (handles pagination). */
+async function fetchBlockedIssues(repo, label, token) {
+  const issues = [];
+  let page = 1;
+  while (true) {
+    const batch = await apiRequest(
+      "GET",
+      `/repos/${repo}/issues?state=open&labels=${encodeURIComponent(label)}&per_page=100&page=${page}`,
+      null,
+      token,
+    );
+    if (!batch.length) break;
+    // GitHub issues API also returns PRs — filter them out
+    issues.push(...batch.filter((i) => !i.pull_request));
+    if (batch.length < 100) break;
+    page++;
+  }
+  return issues;
+}
+
+/** Fetch the most recent comments on an issue (up to 100). */
+async function fetchIssueComments(repo, issueNumber, token) {
+  return apiRequest(
+    "GET",
+    `/repos/${repo}/issues/${issueNumber}/comments?per_page=100&direction=desc`,
+    null,
+    token,
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Staleness check
+// ---------------------------------------------------------------------------
+
+/**
+ * Returns true if the issue has had no activity (updated_at) for >= STALE_DAYS.
+ * `updated_at` covers edits, label changes, and new comments — a good proxy
+ * for "no dependency activity".
+ */
+function isStale(issue) {
+  const updatedAt = new Date(issue.updated_at);
+  const now = new Date();
+  const diffMs = now - updatedAt;
+  const diffDays = diffMs / (1000 * 60 * 60 * 24);
+  return diffDays >= STALE_DAYS;
+}
+
+/**
+ * Returns true if we already posted a nudge comment since the last update,
+ * preventing duplicate nudges within the same staleness window.
+ */
+function alreadyNudged(comments, issueUpdatedAt) {
+  const updatedAt = new Date(issueUpdatedAt);
+  return comments.some(
+    (c) =>
+      c.body &&
+      c.body.includes(NUDGE_MARKER) &&
+      new Date(c.created_at) >= updatedAt,
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Comment template
+// ---------------------------------------------------------------------------
+
+function buildNudgeComment(issue) {
+  const assignees =
+    issue.assignees && issue.assignees.length
+      ? issue.assignees.map((a) => `@${a.login}`).join(", ")
+      : "_unassigned_";
+
+  const labels = issue.labels.map((l) => `\`${l.name}\``).join(", ");
+
+  return [
+    NUDGE_MARKER,
+    "## 🔔 Stale Blocked Issue — Dependency Check",
+    "",
+    `This issue has been marked **\`${BLOCKED_LABEL}\`** and has had no activity for **${STALE_DAYS}+ days**.`,
+    "",
+    `**Assignee(s):** ${assignees}`,
+    `**Labels:** ${labels}`,
+    "",
+    "### Dependency Status Prompts",
+    "",
+    "Please provide an update on the blocking dependency:",
+    "",
+    "- [ ] What is the current status of the blocking issue/PR?",
+    "- [ ] Is there a workaround available that would unblock this?",
+    "- [ ] Does the blocking dependency need to be escalated to a maintainer?",
+    "- [ ] Should this issue be re-scoped or closed as no longer relevant?",
+    "",
+    "> If the blocker has been resolved, remove the `blocked` label and leave a brief status comment.",
+    "> If this issue is no longer actionable, close it with a note.",
+    "",
+    "---",
+    "_This is an automated reminder. No action is required if the dependency is actively being tracked._",
+  ].join("\n");
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+async function main() {
+  const token = process.env.GITHUB_TOKEN;
+  const repo = process.env.GITHUB_REPO;
+
+  if (!token || !repo) {
+    console.error("Missing required env vars: GITHUB_TOKEN, GITHUB_REPO");
+    process.exit(1);
+  }
+
+  console.log(
+    `Config: repo=${repo} label="${BLOCKED_LABEL}" stale_days=${STALE_DAYS} dry_run=${DRY_RUN}`,
+  );
+
+  console.log(`Fetching open issues with label "${BLOCKED_LABEL}"...`);
+  const blockedIssues = await fetchBlockedIssues(repo, BLOCKED_LABEL, token);
+  console.log(`Found ${blockedIssues.length} blocked issue(s)`);
+
+  let nudged = 0;
+  let skippedRecent = 0;
+  let skippedAlreadyNudged = 0;
+
+  for (const issue of blockedIssues) {
+    const { number, title, updated_at } = issue;
+
+    // Skip recently updated issues
+    if (!isStale(issue)) {
+      console.log(`  #${number} — skipped (updated recently): ${title}`);
+      skippedRecent++;
+      continue;
+    }
+
+    // Check for existing nudge comment since last update
+    const comments = await fetchIssueComments(repo, number, token);
+    if (alreadyNudged(comments, updated_at)) {
+      console.log(`  #${number} — skipped (already nudged): ${title}`);
+      skippedAlreadyNudged++;
+      continue;
+    }
+
+    const body = buildNudgeComment(issue);
+
+    if (DRY_RUN) {
+      console.log(`  #${number} — [DRY RUN] would post nudge: ${title}`);
+      console.log("--- comment preview ---");
+      console.log(body);
+      console.log("---");
+    } else {
+      console.log(`  #${number} — posting nudge: ${title}`);
+      await apiRequest(
+        "POST",
+        `/repos/${repo}/issues/${number}/comments`,
+        { body },
+        token,
+      );
+    }
+
+    nudged++;
+  }
+
+  console.log(
+    `\nDone. nudged=${nudged} skipped_recent=${skippedRecent} skipped_already_nudged=${skippedAlreadyNudged}`,
+  );
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
…and issue intake linter

Summary
This PR introduces three GitHub automation bots to improve PR reviewer distribution, prevent stale blocked issues, and enforce consistent issue templates.

Changes Included
1. Reviewer Load-Balancing Suggestion Bot (Medium complexity)
Files:

.github/workflows/reviewer-suggestor.yml

scripts/reviewer-suggestor.ts

Features:

Computes open review count per reviewer

Tracks expertise labels from issue/PR metadata

Posts non-blocking recommendation comment on PR

Honors [skip-reviewer-bot] or manual-assignment labels

Trigger: On PR open, ready for review, or label change

2. Stale-Blocked Issue Nudger (Small complexity)
Files:

.github/workflows/stale-blocked-nudger.yml

scripts/stale-blocked-nudger.ts

Features:

Targets issues with blocked label

Skips issues updated in last configurable window (default: 5 days)

Posts reminder comment with dependency prompts

Configurable via environment variables

Trigger: Scheduled (daily) or manually dispatched

3. Issue Intake Linter (Medium complexity)
Files:

.github/workflows/issue-linter.yml

scripts/issue-linter.ts

Features:

Validates required Wave fields: ID, Track, Phase, Difficulty, Priority, Acceptance, Validation

Runs on issue create/edit events

Posts actionable feedback comment with missing/invalid fields

Blocks malformed issues from being labeled as ready-for-triage

closes #621 
closes #623 
closes #624