### PR TITLE
guardrails: harden indexer burst handling and workflow policy checks

### DIFF
--- a/.github/workflows/secret-scope-policy.yml
+++ b/.github/workflows/secret-scope-policy.yml
@@ -1,0 +1,24 @@
+name: Secret Scope Policy
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/**'
+      - 'scripts/check-secret-scope.sh'
+  push:
+    branches: [main]
+    paths:
+      - '.github/workflows/**'
+      - 'scripts/check-secret-scope.sh'
+
+permissions:
+  contents: read
+
+jobs:
+  policy:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+      - name: Validate workflow secret scope
+        run: bash scripts/check-secret-scope.sh .github/workflows

--- a/backend/src/indexer/indexer.module.ts
+++ b/backend/src/indexer/indexer.module.ts
@@ -8,6 +8,7 @@ import { ProjectionService } from './projections/projection.service';
 import { CursorService } from './projections/cursor.service';
 import { IndexerQueueService } from './queue/indexer-queue.service';
 import { IndexerWorkerService } from './queue/indexer-worker.service';
+import { ReplayAlertService } from './queue/replay-alert.service';
 import { IngestedEventEntity } from './entities/ingested-event.entity';
 import { SessionProjectionEntity } from './entities/session-projection.entity';
 import { IndexerCursorEntity } from './entities/indexer-cursor.entity';
@@ -28,6 +29,7 @@ import { IndexerCursorEntity } from './entities/indexer-cursor.entity';
     ProjectionService,
     CursorService,
     IndexerQueueService,
+    ReplayAlertService,
     IndexerWorkerService,
   ],
   exports: [IndexerService, ProjectionService, CursorService, EventNormalizerService],

--- a/backend/src/indexer/indexer.service.spec.ts
+++ b/backend/src/indexer/indexer.service.spec.ts
@@ -2,6 +2,7 @@ import { IndexerService } from './indexer.service';
 import { EventNormalizerService } from './processors/event-normalizer.service';
 import { EventProcessorService } from './processors/event-processor.service';
 import { CursorService } from './projections/cursor.service';
+import { ReplayAlertService } from './queue/replay-alert.service';
 import { ConfigService } from '@nestjs/config';
 import { INDEXER_STREAM_CORE_GAME } from './indexer.constants';
 
@@ -39,6 +40,7 @@ const makeService = (overrides: {
     new EventNormalizerService(),
     cursorService,
     { get: configGet } as unknown as ConfigService,
+    new ReplayAlertService(),
   );
 
   return { svc, cursorService, eventProcessor };

--- a/backend/src/indexer/indexer.service.ts
+++ b/backend/src/indexer/indexer.service.ts
@@ -8,6 +8,7 @@ import { CursorService } from './projections/cursor.service';
 import { compareEventsByCursor } from './processors/event-ordering.util';
 import { randomUUID } from 'crypto';
 import { INDEXER_STREAM_CORE_GAME } from './indexer.constants';
+import { ReplayAlertService } from './queue/replay-alert.service';
 
 export interface IndexerLogContext {
   correlationId: string;
@@ -57,6 +58,7 @@ export class IndexerService {
     private readonly eventNormalizer: EventNormalizerService,
     private readonly cursorService: CursorService,
     private readonly configService: ConfigService,
+    private readonly replayAlertService: ReplayAlertService,
   ) {}
 
   async ingest(event: IngestedEventDto, context?: IndexerLogContext) {
@@ -126,7 +128,6 @@ export class IndexerService {
     };
   }
 
-  async poll(): Promise<number> {
   async poll(context?: IndexerLogContext): Promise<number> {
     const network =
       (this.configService.get<string>('SOROBAN_NETWORK') as 'testnet' | 'mainnet') ||
@@ -228,9 +229,9 @@ export class IndexerService {
     return response.data?.result?.latestLedger ?? 0;
   }
 
-  recordReplaySkip(ledger: number, txHash: string, eventIndex: number) {
   recordReplaySkip(ledger: number, txHash: string, eventIndex: number, context?: IndexerLogContext) {
     this.metrics.replaySkips++;
+    const alert = this.replayAlertService.recordReplayRejection(ledger, txHash, eventIndex);
     this.logger.warn({
       msg: 'indexer.replay.skip',
       correlationId: context?.correlationId,
@@ -238,6 +239,7 @@ export class IndexerService {
       txHash,
       eventIndex,
       totalSkips: this.metrics.replaySkips,
+      replayAlert: alert.isAlerting ? 'threshold_exceeded' : 'below_threshold',
     });
   }
 }

--- a/backend/src/indexer/queue/indexer-queue.constants.ts
+++ b/backend/src/indexer/queue/indexer-queue.constants.ts
@@ -1,0 +1,1 @@
+export const INDEXER_QUEUE_MAX_BUFFER_SIZE = 500;

--- a/backend/src/indexer/queue/indexer-queue.service.spec.ts
+++ b/backend/src/indexer/queue/indexer-queue.service.spec.ts
@@ -66,4 +66,21 @@ describe('IndexerQueueService', () => {
     await service.enqueue(makeEvent(2, 'tx-b', 0));
     expect(service.size()).toBe(2);
   });
+
+  it('rejects events once the bounded buffer is full', async () => {
+    const warnSpy = jest.spyOn((service as { logger: { warn: (...args: unknown[]) => void } }).logger, 'warn');
+
+    for (let i = 0; i < 500; i += 1) {
+      expect(await service.enqueue(makeEvent(i + 1, `tx-${i}`, 0))).toBe(true);
+    }
+
+    await expect(service.enqueue(makeEvent(999, 'tx-overflow', 0))).resolves.toBe(false);
+    expect(service.size()).toBe(500);
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        msg: 'indexer.queue.rejected',
+        reason: 'buffer_limit_reached',
+      }),
+    );
+  });
 });

--- a/backend/src/indexer/queue/indexer-queue.service.ts
+++ b/backend/src/indexer/queue/indexer-queue.service.ts
@@ -1,6 +1,7 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { IngestedEventDto } from '../dto/ingested-event.dto';
 import { compareEventsByCursor } from '../processors/event-ordering.util';
+import { INDEXER_QUEUE_MAX_BUFFER_SIZE } from './indexer-queue.constants';
 
 @Injectable()
 export class IndexerQueueService {
@@ -8,10 +9,24 @@ export class IndexerQueueService {
   private readonly buffer: IngestedEventDto[] = [];
 
   async enqueue(event: IngestedEventDto) {
+    if (this.buffer.length >= INDEXER_QUEUE_MAX_BUFFER_SIZE) {
+      this.logger.warn({
+        msg: 'indexer.queue.rejected',
+        reason: 'buffer_limit_reached',
+        bufferSize: this.buffer.length,
+        bufferLimit: INDEXER_QUEUE_MAX_BUFFER_SIZE,
+        ledger: event.ledger,
+        txHash: event.txHash,
+        eventIndex: event.eventIndex,
+      });
+      return false;
+    }
+
     this.buffer.push(event);
     this.buffer.sort(compareEventsByCursor);
 
     this.logger.debug(`Queued event ${event.topic} at ${event.txHash}#${event.eventIndex}`);
+    return true;
   }
 
   drain(): IngestedEventDto[] {

--- a/backend/src/indexer/queue/indexer-worker.service.ts
+++ b/backend/src/indexer/queue/indexer-worker.service.ts
@@ -5,6 +5,7 @@ import { Cron, CronExpression } from '@nestjs/schedule';
 import { IndexerService } from '../indexer.service';
 import { INDEXER_NETWORK_TESTNET, INDEXER_STREAM_CORE_GAME } from '../indexer.constants';
 import { CursorService } from '../projections/cursor.service';
+import { ReplayAlertService } from './replay-alert.service';
 
 @Injectable()
 export class IndexerWorkerService {
@@ -14,6 +15,7 @@ export class IndexerWorkerService {
     private readonly indexerService: IndexerService,
     private readonly cursorService: CursorService,
     private readonly configService: ConfigService,
+    private readonly replayAlertService: ReplayAlertService,
   ) {}
 
   @Cron(CronExpression.EVERY_10_SECONDS)
@@ -30,6 +32,7 @@ export class IndexerWorkerService {
       cursorTxHash: cursor.lastTxHash,
       cursorEventIndex: cursor.lastEventIndex,
       metrics: { ...this.indexerService.metrics },
+      replayAlert: this.replayAlertService.snapshot(),
     });
 
     await this.indexerService.poll({ correlationId });

--- a/backend/src/indexer/queue/replay-alert.constants.ts
+++ b/backend/src/indexer/queue/replay-alert.constants.ts
@@ -1,0 +1,1 @@
+export const REPLAY_REJECTION_ALERT_THRESHOLD = 5;

--- a/backend/src/indexer/queue/replay-alert.service.spec.ts
+++ b/backend/src/indexer/queue/replay-alert.service.spec.ts
@@ -1,0 +1,34 @@
+import { ReplayAlertService } from './replay-alert.service';
+
+describe('ReplayAlertService', () => {
+  let service: ReplayAlertService;
+
+  beforeEach(() => {
+    service = new ReplayAlertService();
+  });
+
+  it('tracks replay rejections and flips to alerting after the threshold', () => {
+    for (let i = 0; i < 4; i += 1) {
+      const snapshot = service.recordReplayRejection(100 + i, `tx-${i}`, i);
+      expect(snapshot.isAlerting).toBe(false);
+      expect(snapshot.windowSkips).toBe(i + 1);
+    }
+
+    const thresholdSnapshot = service.recordReplayRejection(200, 'tx-alert', 0);
+
+    expect(thresholdSnapshot.windowSkips).toBe(5);
+    expect(thresholdSnapshot.threshold).toBe(5);
+    expect(thresholdSnapshot.isAlerting).toBe(true);
+    expect(thresholdSnapshot.lastRejectedAt).toBeInstanceOf(Date);
+  });
+
+  it('resetWindow clears alert state', () => {
+    service.recordReplayRejection(1, 'tx-a', 0);
+    service.resetWindow();
+
+    const snapshot = service.snapshot();
+    expect(snapshot.windowSkips).toBe(0);
+    expect(snapshot.isAlerting).toBe(false);
+    expect(snapshot.lastRejectedAt).toBeUndefined();
+  });
+});

--- a/backend/src/indexer/queue/replay-alert.service.ts
+++ b/backend/src/indexer/queue/replay-alert.service.ts
@@ -1,0 +1,53 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { REPLAY_REJECTION_ALERT_THRESHOLD } from './replay-alert.constants';
+
+export interface ReplayAlertSnapshot {
+  windowSkips: number;
+  threshold: number;
+  isAlerting: boolean;
+  lastRejectedAt?: Date;
+}
+
+@Injectable()
+export class ReplayAlertService {
+  private readonly logger = new Logger(ReplayAlertService.name);
+  private windowSkips = 0;
+  private lastRejectedAt?: Date;
+  private readonly threshold = REPLAY_REJECTION_ALERT_THRESHOLD;
+
+  recordReplayRejection(
+    ledger: number,
+    txHash: string,
+    eventIndex: number,
+  ): ReplayAlertSnapshot {
+    this.windowSkips += 1;
+    this.lastRejectedAt = new Date();
+
+    const snapshot = this.snapshot();
+    this.logger.warn({
+      msg: 'indexer.replay.rejected',
+      ledger,
+      txHash,
+      eventIndex,
+      windowSkips: snapshot.windowSkips,
+      threshold: snapshot.threshold,
+      alert: snapshot.isAlerting ? 'replay_rejection_threshold_exceeded' : 'replay_rejection_observed',
+    });
+
+    return snapshot;
+  }
+
+  snapshot(): ReplayAlertSnapshot {
+    return {
+      windowSkips: this.windowSkips,
+      threshold: this.threshold,
+      isAlerting: this.windowSkips >= this.threshold,
+      lastRejectedAt: this.lastRejectedAt,
+    };
+  }
+
+  resetWindow(): void {
+    this.windowSkips = 0;
+    this.lastRejectedAt = undefined;
+  }
+}

--- a/docs/SECURITY_FOUNDATION.md
+++ b/docs/SECURITY_FOUNDATION.md
@@ -11,6 +11,8 @@
 - Event replay safety with unique key `(network, txHash, eventIndex)`.
 - Projection updates are idempotent by design.
 - Cursor checkpoint model added for deterministic polling progress.
+- Bounded queue buffering rejects bursts once `INDEXER_QUEUE_MAX_BUFFER_SIZE` is reached.
+- Replay rejection alerts emit structured threshold snapshots for operational visibility.
 
 ## Frontend wallet
 - Explicit tx lifecycle states (signing/submitting/success/error).
@@ -65,6 +67,7 @@ Covers `core_game`, `rewards`, `achievements` Soroban contracts and the backend 
 - Projection `apply()` is idempotent: upsert by `(network, sessionId)` overwrites rather than appends.
 - Payload size guard (configurable via `INDEXER_MAX_PAYLOAD_BYTES`) rejects oversized payloads that could carry embedded replay data.
 - Topic allowlist (`ALLOWED_TOPICS`) rejects unknown event types at normalization time.
+- Queue backpressure guard rejects oversized bursts before they can accumulate in memory.
 
 **Owner module:** `backend/src/indexer`  
 **Mitigation tests:** `event-normalizer.service.spec.ts` — allowlist and payload-size guard tests.  
@@ -110,3 +113,12 @@ Covers `core_game`, `rewards`, `achievements` Soroban contracts and the backend 
 | 3 | Ingestion pipeline replay | High | Mitigated | #606 (HMAC on ingest) |
 | 4 | Cross-network replay | Medium | Mitigated | — |
 | 5 | Reward/achievement double-claim | High | Partial | #607 (on-chain claimed-flag tests) |
+
+---
+
+## Pre-testnet Hardening Checklist
+
+- Confirm replay rejection alerts are visible in worker tick logs.
+- Verify the indexer queue rejects burst traffic once the bounded buffer is full.
+- Run the workflow secret-scope policy check before merging workflow changes.
+- Keep security notes and wave docs aligned with any behavior changes.

--- a/docs/wave/WAVE5_PHASE2_PROGRESS.md
+++ b/docs/wave/WAVE5_PHASE2_PROGRESS.md
@@ -35,10 +35,16 @@ Technical boundaries remain aligned with:
 - Added event normalization service and deterministic event ordering utility.
 - Expanded cursor schema with event index checkpointing.
 - Expanded indexer service flow to checkpoint after replay-safe ingestion.
+- Added bounded queue rejection guards and replay alert snapshots for burst visibility.
 
 5. Testing Foundations
 - Added contract-level smoke test scaffolding in `core_game`.
 - Added backend indexer unit tests for normalization and cursor ordering invariants.
+- Added queue rejection and replay alert coverage for indexer hardening.
+
+6. DevOps and Security Policy
+- Added workflow secret-scope policy checks for CI workflow maintenance.
+- Documented the pre-testnet hardening checklist in `docs/SECURITY_FOUNDATION.md`.
 
 ## Out of Scope (Intentionally Deferred)
 

--- a/scripts/check-secret-scope.sh
+++ b/scripts/check-secret-scope.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+WORKFLOW_DIR="${1:-.github/workflows}"
+
+if [[ ! -d "$WORKFLOW_DIR" ]]; then
+  echo "Workflow directory not found: $WORKFLOW_DIR" >&2
+  exit 1
+fi
+
+failures=0
+
+while IFS= read -r -d '' file; do
+  if grep -nE 'secrets:\s*inherit|secrets\.[A-Z0-9_]+|secrets\[[^]]+\]' "$file" >/dev/null; then
+    echo "ERROR: overly broad secret usage detected in $file" >&2
+    grep -nE 'secrets:\s*inherit|secrets\.[A-Z0-9_]+|secrets\[[^]]+\]' "$file" >&2 || true
+    failures=1
+  fi
+done < <(find "$WORKFLOW_DIR" -maxdepth 1 \( -name '*.yml' -o -name '*.yaml' \) -print0)
+
+if [[ "$failures" -ne 0 ]]; then
+  exit 1
+fi
+
+echo "Workflow secret scope policy passed."


### PR DESCRIPTION
Summary\n- Add bounded indexer queue rejection so burst traffic cannot grow memory unbounded.\n- Emit structured replay rejection alerts from the indexer worker and service.\n- Add a workflow secret-scope policy script and CI workflow gate.\n- Update security foundation notes and the phase 2 progress doc to reflect the new hardening checklist.\n\nValidation\n- Added tests for queue bounding and replay alert thresholding.\n- Added a shell policy check for workflow secret scope patterns.\n\nCloses #645\nCloses #646\nCloses #647\nCloses #648