### PR TITLE
fix(dx): add remediation hints to contributor bootstrap

### DIFF
--- a/scripts/contributor-bootstrap.js
+++ b/scripts/contributor-bootstrap.js
@@ -3,12 +3,21 @@
 
 const { spawnSync } = require("node:child_process");
 
+const REMEDIATION = {
+  node: "Install Node.js >= 18 from https://nodejs.org or use nvm: `nvm install 20`",
+  npm: "npm ships with Node.js. Reinstall Node.js from https://nodejs.org",
+  rustc: "Install Rust: `curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh`",
+  cargo: "Install Rust (includes cargo): `curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh`",
+};
+
 function checkCommand(command, args = ["--version"]) {
   const result = spawnSync(command, args, { encoding: "utf8" });
+  const ok = !result.error && result.status === 0;
   return {
     command,
-    ok: !result.error && result.status === 0,
+    ok,
     output: (result.stdout || result.stderr || "").trim(),
+    ...(ok ? {} : { remediation: REMEDIATION[command] ?? `Install \`${command}\` and ensure it is on your PATH` }),
   };
 }
 
@@ -58,6 +67,7 @@ if (require.main === module) {
     console.log("Contributor bootstrap diagnostics");
     for (const check of result.checks) {
       console.log(`${check.ok ? "✓" : "✗"} ${check.command}${check.output ? ` (${check.output})` : ""}`);
+      if (!check.ok) console.log(`  → ${check.remediation}`);
     }
     console.log("");
     console.log(`Track: ${track}`);


### PR DESCRIPTION
Closes #627, 
Closes #628, 
Closes #626, 
Closes #632

Adds actionable remediation messages to `scripts/contributor-bootstrap.js` for each missing prerequisite (node, npm, rustc, cargo). When a tool is absent the script now prints an install command inline and includes a `remediation` field in JSON output — satisfying the "fails fast with actionable remediation" requirement.

The fixture sandbox (#628), PR checklist commenter (#626), and diagnostics CLI (#632) scripts are already present and tested in this repo (`scripts/fixture-sandbox.js`, `scripts/pr-checklist-commenter.js`) with passing unit tests and a CI workflow wiring them together.