### PR TITLE
Add replay rejection alert tagging for the indexer worker

### DIFF
--- a/backend/src/indexer/queue/indexer-worker.service.spec.ts
+++ b/backend/src/indexer/queue/indexer-worker.service.spec.ts
@@ -1,0 +1,62 @@
+import { IndexerWorkerService } from './indexer-worker.service';
+import { ReplayAlertService } from './replay-alert.service';
+import { INDEXER_NETWORK_TESTNET, INDEXER_STREAM_CORE_GAME } from '../indexer.constants';
+
+describe('IndexerWorkerService', () => {
+  it('includes replay alert tags in the worker tick log payload', async () => {
+    const loggerLog = jest.fn();
+    const loggerWarn = jest.fn();
+
+    const indexerService = {
+      metrics: { replaySkips: 6, ingestedTotal: 10, projectionErrors: 0, pollCycles: 3 },
+      poll: jest.fn().mockResolvedValue(0),
+    } as any;
+
+    const cursorService = {
+      getOrCreate: jest.fn().mockResolvedValue({
+        lastLedger: 99,
+        lastTxHash: 'tx-1',
+        lastEventIndex: 2,
+      }),
+    } as any;
+
+    const configService = {
+      get: jest.fn().mockReturnValue(INDEXER_NETWORK_TESTNET),
+    } as any;
+
+    const replayAlertService = new ReplayAlertService();
+    jest.spyOn(replayAlertService, 'snapshot').mockReturnValue({
+      windowSkips: 5,
+      threshold: 5,
+      isAlerting: true,
+      lastRejectedAt: new Date('2026-05-30T00:00:00.000Z'),
+      alertTag: 'replay_rejection_threshold_exceeded',
+    });
+
+    const worker = new IndexerWorkerService(
+      indexerService,
+      cursorService,
+      configService,
+      replayAlertService,
+    );
+
+    (worker as unknown as { logger: { log: typeof loggerLog } }).logger.log = loggerLog;
+    (worker as unknown as { logger: { warn: typeof loggerWarn } }).logger.warn = loggerWarn;
+
+    await worker.tick();
+
+    expect(cursorService.getOrCreate).toHaveBeenCalledWith(
+      INDEXER_NETWORK_TESTNET,
+      INDEXER_STREAM_CORE_GAME,
+    );
+    expect(loggerLog).toHaveBeenCalledWith(
+      expect.objectContaining({
+        msg: 'indexer.worker.tick',
+        replayAlertTag: 'replay_rejection_threshold_exceeded',
+      }),
+    );
+    expect(indexerService.poll).toHaveBeenCalledWith(
+      expect.objectContaining({ correlationId: expect.any(String) }),
+    );
+  });
+});

--- a/backend/src/indexer/queue/indexer-worker.service.ts
+++ b/backend/src/indexer/queue/indexer-worker.service.ts
@@ -23,6 +23,7 @@ export class IndexerWorkerService {
     const correlationId = randomUUID();
     const network = this.configService.get<string>('SOROBAN_NETWORK') || INDEXER_NETWORK_TESTNET;
     const cursor = await this.cursorService.getOrCreate(network, INDEXER_STREAM_CORE_GAME);
+    const replayAlert = this.replayAlertService.snapshot();
 
     this.logger.log({
       msg: 'indexer.worker.tick',
@@ -32,7 +33,8 @@ export class IndexerWorkerService {
       cursorTxHash: cursor.lastTxHash,
       cursorEventIndex: cursor.lastEventIndex,
       metrics: { ...this.indexerService.metrics },
-      replayAlert: this.replayAlertService.snapshot(),
+      replayAlert,
+      replayAlertTag: replayAlert.alertTag,
     });
 
     await this.indexerService.poll({ correlationId });

--- a/backend/src/indexer/queue/replay-alert.service.ts
+++ b/backend/src/indexer/queue/replay-alert.service.ts
@@ -6,6 +6,7 @@ export interface ReplayAlertSnapshot {
   threshold: number;
   isAlerting: boolean;
   lastRejectedAt?: Date;
+  alertTag: string;
 }
 
 @Injectable()
@@ -31,18 +32,22 @@ export class ReplayAlertService {
       eventIndex,
       windowSkips: snapshot.windowSkips,
       threshold: snapshot.threshold,
-      alert: snapshot.isAlerting ? 'replay_rejection_threshold_exceeded' : 'replay_rejection_observed',
+      alert: snapshot.alertTag,
     });
 
     return snapshot;
   }
 
   snapshot(): ReplayAlertSnapshot {
+    const isAlerting = this.windowSkips >= this.threshold;
     return {
       windowSkips: this.windowSkips,
       threshold: this.threshold,
-      isAlerting: this.windowSkips >= this.threshold,
+      isAlerting,
       lastRejectedAt: this.lastRejectedAt,
+      alertTag: isAlerting
+        ? 'replay_rejection_threshold_exceeded'
+        : 'replay_rejection_observed',
     };
   }
 


### PR DESCRIPTION
This PR adds a stable alert tag to replay-rejection snapshots and surfaces it from the indexer worker log so repeated threshold crossings are easier to detect and route.

Closes #645, closes #646, closes #647, and closes #648.

Summary:
- replay alert snapshots now include a stable alertTag
- the worker log now emits the alert tag alongside the replay snapshot
- adds a regression test for the worker log payload