### PR TITLE
Frontend wallet status sandbox route

### DIFF
--- a/frontend/src/app/sandbox/wallet-status/page.tsx
+++ b/frontend/src/app/sandbox/wallet-status/page.tsx
@@ -1,0 +1,6 @@
+import { WalletStatusSandbox } from "./wallet-status-sandbox";
+
+export default function WalletStatusSandboxPage() {
+  return <WalletStatusSandbox />;
+}
+

--- a/frontend/src/app/sandbox/wallet-status/wallet-status-sandbox.tsx
+++ b/frontend/src/app/sandbox/wallet-status/wallet-status-sandbox.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+import { useStellarWallet } from "@/hooks/useStellarWallet";
+import { ActionButton } from "./widgets/action-button";
+import { WalletStatusCard } from "./widgets/wallet-status-card";
+import { STATUS_PRESETS } from "./widgets/status-presets";
+
+export function WalletStatusSandbox() {
+  const wallet = useStellarWallet();
+
+  return (
+    <section className="w-full max-w-5xl mx-auto px-4 py-10 text-primary-50">
+      <header className="mb-6">
+        <h1 className="text-2xl font-semibold tracking-tight">Wallet Status Sandbox</h1>
+        <p className="text-sm text-primary-200 mt-1">
+          Quick visual states for the wallet UI and tx lifecycle.
+        </p>
+      </header>
+
+      <div className="grid gap-4 md:grid-cols-2">
+        <WalletStatusCard
+          title="Current Context"
+          rows={[
+            ["connected", String(wallet.connected)],
+            ["address", wallet.address ?? "(none)"],
+            ["network", wallet.network],
+            ["status.state", wallet.status.state],
+          ]}
+          json={wallet.status}
+        />
+
+        <WalletStatusCard
+          title="Actions"
+          rows={STATUS_PRESETS.map((p) => [p.label, p.status.state])}
+          footer={
+            <div className="flex flex-wrap gap-2">
+              {STATUS_PRESETS.map((p) => (
+                <ActionButton
+                  key={p.label}
+                  onClick={() => wallet.setTxStatus(p.status)}
+                  label={p.label}
+                />
+              ))}
+              <ActionButton
+                onClick={() => wallet.disconnect()}
+                label="Reset (disconnect)"
+                tone="danger"
+              />
+            </div>
+          }
+        />
+      </div>
+    </section>
+  );
+}
+

--- a/frontend/src/app/sandbox/wallet-status/widgets/action-button.tsx
+++ b/frontend/src/app/sandbox/wallet-status/widgets/action-button.tsx
@@ -1,0 +1,23 @@
+"use client";
+
+type Props = {
+  label: string;
+  onClick: () => void;
+  tone?: "default" | "danger";
+};
+
+export function ActionButton({ label, onClick, tone = "default" }: Props) {
+  const base =
+    "px-3 py-2 rounded-md text-sm font-medium border transition-colors select-none";
+  const style =
+    tone === "danger"
+      ? "bg-red-950/40 border-red-900/60 hover:bg-red-950/60 text-red-100"
+      : "bg-primary-900/30 border-primary-700/50 hover:bg-primary-900/50 text-primary-50";
+
+  return (
+    <button type="button" className={`${base} ${style}`} onClick={onClick}>
+      {label}
+    </button>
+  );
+}
+

--- a/frontend/src/app/sandbox/wallet-status/widgets/status-presets.ts
+++ b/frontend/src/app/sandbox/wallet-status/widgets/status-presets.ts
@@ -1,0 +1,10 @@
+import type { TxLifecycleStatus } from "@/lib/stellar/soroban";
+
+export const STATUS_PRESETS: Array<{ label: string; status: TxLifecycleStatus }> = [
+  { label: "Idle", status: { id: "sandbox", state: "idle" } },
+  { label: "Signing", status: { id: "sandbox", state: "signing" } },
+  { label: "Submitting", status: { id: "sandbox", state: "submitting" } },
+  { label: "Success", status: { id: "sandbox", state: "success", txHash: "FAKE_HASH" } },
+  { label: "Error", status: { id: "sandbox", state: "error", error: "User rejected" } },
+];
+

--- a/frontend/src/app/sandbox/wallet-status/widgets/wallet-status-card.tsx
+++ b/frontend/src/app/sandbox/wallet-status/widgets/wallet-status-card.tsx
@@ -1,0 +1,33 @@
+import type { ReactNode } from "react";
+
+type Row = [label: string, value: string];
+
+type Props = {
+  title: string;
+  rows: Row[];
+  json?: unknown;
+  footer?: ReactNode;
+};
+
+export function WalletStatusCard({ title, rows, json, footer }: Props) {
+  return (
+    <div className="rounded-xl border border-primary-800/60 bg-primary-950/40 p-4">
+      <h2 className="text-sm font-semibold text-primary-100">{title}</h2>
+      <dl className="mt-3 space-y-2">
+        {rows.map(([k, v]) => (
+          <div key={k} className="flex items-center justify-between gap-4">
+            <dt className="text-xs text-primary-300">{k}</dt>
+            <dd className="text-xs font-mono text-primary-100 truncate">{v}</dd>
+          </div>
+        ))}
+      </dl>
+      {json ? (
+        <pre className="mt-4 text-xs text-primary-100/90 bg-black/20 rounded-lg p-3 overflow-auto">
+          {JSON.stringify(json, null, 2)}
+        </pre>
+      ) : null}
+      {footer ? <div className="mt-4">{footer}</div> : null}
+    </div>
+  );
+}
+


### PR DESCRIPTION
Adds a small Next.js sandbox page to visualize wallet connection + tx lifecycle states without needing the full gameplay flow.

Route: `/sandbox/wallet-status`

Closes #641
Closes #642
Closes #643
Closes #644
