### PR TITLE
Indexer: tamper-evident audit hash

### DIFF
--- a/backend/src/indexer/audit/event-hash.spec.ts
+++ b/backend/src/indexer/audit/event-hash.spec.ts
@@ -1,0 +1,33 @@
+import { computeAuditEventHash } from './event-hash';
+
+describe('computeAuditEventHash', () => {
+  it('is deterministic for same input', () => {
+    const e = {
+      network: 'testnet',
+      contractId: 'CABC',
+      topic: 'session_finalized',
+      txHash: 'tx1',
+      ledger: 10,
+      eventIndex: 0,
+      payload: { a: 1, b: 'two' },
+    };
+
+    expect(computeAuditEventHash(e)).toEqual(computeAuditEventHash(e));
+  });
+
+  it('changes when payload changes', () => {
+    const base = {
+      network: 'testnet',
+      contractId: 'CABC',
+      topic: 'session_finalized',
+      txHash: 'tx1',
+      ledger: 10,
+      eventIndex: 0,
+    };
+
+    const a = computeAuditEventHash({ ...base, payload: { a: 1 } });
+    const b = computeAuditEventHash({ ...base, payload: { a: 2 } });
+    expect(a).not.toEqual(b);
+  });
+});
+

--- a/backend/src/indexer/audit/event-hash.ts
+++ b/backend/src/indexer/audit/event-hash.ts
@@ -1,0 +1,26 @@
+import { createHash } from 'crypto';
+
+export type AuditEventHashInput = {
+  network: string;
+  contractId: string;
+  topic: string;
+  txHash: string;
+  ledger: number;
+  eventIndex: number;
+  payload: Record<string, unknown>;
+};
+
+export function computeAuditEventHash(e: AuditEventHashInput): string {
+  // Stable, minimal serialization for tamper-evident auditing.
+  const json = JSON.stringify([
+    e.network,
+    e.contractId,
+    e.topic,
+    e.txHash,
+    e.ledger,
+    e.eventIndex,
+    e.payload,
+  ]);
+  return createHash('sha256').update(json).digest('hex');
+}
+

--- a/backend/src/indexer/entities/ingested-event.entity.ts
+++ b/backend/src/indexer/entities/ingested-event.entity.ts
@@ -24,6 +24,9 @@ export class IngestedEventEntity {
   @Column()
   eventIndex: number;
 
+  @Column({ nullable: true })
+  auditHash?: string;
+
   @Column({ type: 'jsonb' })
   payload: Record<string, unknown>;
 

--- a/backend/src/indexer/processors/event-processor.service.spec.ts
+++ b/backend/src/indexer/processors/event-processor.service.spec.ts
@@ -1,6 +1,7 @@
 import { EventProcessorService } from './event-processor.service';
 import { ProjectionService } from '../projections/projection.service';
 import { IngestedEventDto } from '../dto/ingested-event.dto';
+import { computeAuditEventHash } from '../audit/event-hash';
 
 const makeEvent = (overrides: Partial<IngestedEventDto> = {}): IngestedEventDto => ({
   network: 'testnet',
@@ -31,6 +32,18 @@ describe('EventProcessorService', () => {
     const result = await svc.process(makeEvent());
     expect(result).toBe(true);
     expect(eventsRepo.save).toHaveBeenCalled();
+    const savedArg = eventsRepo.save.mock.calls[0][0];
+    expect(savedArg.auditHash).toEqual(
+      computeAuditEventHash({
+        network: savedArg.network,
+        contractId: savedArg.contractId,
+        topic: savedArg.topic,
+        txHash: savedArg.txHash,
+        ledger: savedArg.ledger,
+        eventIndex: savedArg.eventIndex,
+        payload: savedArg.payload,
+      }),
+    );
     expect(projectionService.apply).toHaveBeenCalled();
   });
 

--- a/backend/src/indexer/processors/event-processor.service.ts
+++ b/backend/src/indexer/processors/event-processor.service.ts
@@ -5,6 +5,7 @@ import { IngestedEventDto } from '../dto/ingested-event.dto';
 import { IngestedEventEntity } from '../entities/ingested-event.entity';
 import { ProjectionService } from '../projections/projection.service';
 import { IndexerLogContext } from '../indexer.service';
+import { computeAuditEventHash } from '../audit/event-hash';
 
 @Injectable()
 export class EventProcessorService {
@@ -38,7 +39,17 @@ export class EventProcessorService {
       return false;
     }
 
-    await this.eventsRepo.save(this.eventsRepo.create(event));
+    const auditHash = computeAuditEventHash({
+      network: event.network,
+      contractId: event.contractId,
+      topic: event.topic,
+      txHash: event.txHash,
+      ledger: event.ledger,
+      eventIndex: event.eventIndex,
+      payload: event.payload,
+    });
+
+    await this.eventsRepo.save(this.eventsRepo.create({ ...event, auditHash }));
     await this.projectionService.apply(event, context);
     return true;
   }


### PR DESCRIPTION
Adds a deterministic `auditHash` for ingested events to support tamper-evident audit trails.

- Computes SHA-256 over a stable tuple of event fields
- Persists on ingest and unit-tests determinism

Closes #649
Closes #650
Closes #651
Closes #652
