### PR TITLE
feat(AI/AUTOMATION-209): build oversized issue split suggester for backlog hygiene

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,7 @@ permissions:
 jobs:
   lockfile-guard:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - uses: actions/checkout@v4
       - name: Check frontend lockfile is in sync with package.json

--- a/.github/workflows/oversized-issue-split-suggester.yml
+++ b/.github/workflows/oversized-issue-split-suggester.yml
@@ -1,0 +1,42 @@
+name: Oversized Issue Split Suggester
+
+on:
+  schedule:
+    - cron: "0 7 * * 1" # Every Monday at 07:00 UTC
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Print report without non-zero exit (true/false)"
+        required: false
+        default: "true"
+      output_json:
+        description: "Emit JSON output (true/false)"
+        required: false
+        default: "false"
+
+permissions:
+  issues: read
+  contents: read
+
+jobs:
+  suggest-splits:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Run unit tests
+        run: node --test scripts/oversized-issue-split-suggester.test.js
+
+      - name: Suggest split candidates
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPO: ${{ github.repository }}
+          DRY_RUN: ${{ github.event.inputs.dry_run || 'true' }}
+          OUTPUT_JSON: ${{ github.event.inputs.output_json || 'false' }}
+        run: node scripts/oversized-issue-split-suggester.js

--- a/.github/workflows/oversized-issue-split-suggester.yml
+++ b/.github/workflows/oversized-issue-split-suggester.yml
@@ -35,7 +35,7 @@ jobs:
 
       - name: Suggest split candidates
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ github.token }}
           GITHUB_REPO: ${{ github.repository }}
           DRY_RUN: ${{ github.event.inputs.dry_run || 'true' }}
           OUTPUT_JSON: ${{ github.event.inputs.output_json || 'false' }}

--- a/docs/wave/OVERSIZED_ISSUE_SPLIT_SUGGESTER.md
+++ b/docs/wave/OVERSIZED_ISSUE_SPLIT_SUGGESTER.md
@@ -1,0 +1,54 @@
+# Oversized Issue Split Suggester
+
+**Script:** `scripts/oversized-issue-split-suggester.js`
+**Workflow:** `.github/workflows/oversized-issue-split-suggester.yml`
+
+## Purpose
+
+Some backlog items are too broad for a single contributor cycle. This tool
+scans all open issues and surfaces split candidates using five heuristics,
+then proposes concrete seam suggestions — without modifying any GitHub issue.
+
+## Heuristics
+
+| Heuristic | Condition | Default threshold |
+|---|---|---|
+| `body_length` | Issue body exceeds character limit | 1500 chars |
+| `ac_count` | More than N acceptance-criteria checkbox items | 5 items |
+| `multi_track` | Issue carries more than one `track:*` label | 2 tracks |
+| `blocker_count` | Depends on ≥ N blocking issues | 3 blockers |
+| `size_label` | Carries `size:L` or `size:XL` label | — |
+
+All thresholds are tunable via env vars: `BODY_CHARS_THRESHOLD`, `AC_COUNT_THRESHOLD`, `BLOCKERS_THRESHOLD`.
+
+## Running locally
+
+```bash
+GITHUB_TOKEN=<pat> GITHUB_REPO=owner/repo node scripts/oversized-issue-split-suggester.js
+```
+
+Use `DRY_RUN=true` (default) to print the report without failing CI, or
+`OUTPUT_JSON=true` for machine-readable output.
+
+## Output example
+
+```
+=== Oversized Issue Split Suggester ===
+Scanned:    42 open issues
+Candidates: 2 issues flagged for potential split
+
+Issue #17: Implement full Soroban migration
+  URL: https://github.com/...
+  Triggers:
+    • [multi_track] Spans 3 tracks: track:FE, track:BE, track:SC
+    • [ac_count] 8 acceptance criteria items (threshold: 5)
+  Suggested split seams:
+    → Split acceptance criteria into two issues: first 4 items in one issue, remaining in another.
+    → Create one child issue per track label so each can be claimed independently.
+```
+
+## Schedule
+
+Runs every Monday at **07:00 UTC** and on-demand via `workflow_dispatch`.
+The workflow defaults `DRY_RUN=true` so it never fails CI, serving as an
+informational report only.

--- a/scripts/oversized-issue-split-suggester.js
+++ b/scripts/oversized-issue-split-suggester.js
@@ -1,0 +1,328 @@
+#!/usr/bin/env node
+/**
+ * Oversized Issue Split Suggester (AI/AUTOMATION-209)
+ *
+ * Scans open issues for patterns that indicate the issue is too broad for a
+ * single contributor cycle, then outputs suggested split seams without
+ * mutating any GitHub issue directly.
+ *
+ * Heuristics applied (all thresholds tunable via env vars):
+ *   1. Body length     — bodies over BODY_CHARS_THRESHOLD chars are candidates.
+ *   2. Acceptance-criteria count — more than AC_COUNT_THRESHOLD AC items.
+ *   3. Multi-track labels — issue carries labels for more than one track.
+ *   4. Multiple "Blocked By" targets — depends on ≥ BLOCKERS_THRESHOLD issues.
+ *   5. Size label      — explicit `size:L` or `size:XL` label.
+ *
+ * Usage:
+ *   node scripts/oversized-issue-split-suggester.js
+ *
+ * Required env vars:
+ *   GITHUB_TOKEN  - token with repo read permissions
+ *   GITHUB_REPO   - owner/repo (e.g. "org/dewordle")
+ *
+ * Optional env vars:
+ *   BODY_CHARS_THRESHOLD  - default 1500
+ *   AC_COUNT_THRESHOLD    - default 5
+ *   BLOCKERS_THRESHOLD    - default 3
+ *   OUTPUT_JSON           - "true" for machine-readable JSON
+ *   DRY_RUN               - "true" to skip non-zero exit on findings
+ */
+
+"use strict";
+
+const https = require("https");
+
+// ---------------------------------------------------------------------------
+// Config
+// ---------------------------------------------------------------------------
+
+const BODY_CHARS_THRESHOLD = parseInt(
+  process.env.BODY_CHARS_THRESHOLD || "1500",
+  10,
+);
+const AC_COUNT_THRESHOLD = parseInt(process.env.AC_COUNT_THRESHOLD || "5", 10);
+const BLOCKERS_THRESHOLD = parseInt(process.env.BLOCKERS_THRESHOLD || "3", 10);
+const OUTPUT_JSON = process.env.OUTPUT_JSON === "true";
+const DRY_RUN = process.env.DRY_RUN === "true";
+
+const OVERSIZED_SIZE_LABELS = new Set(["size:l", "size:xl"]);
+const TRACK_LABEL_PREFIX = "track:";
+
+// ---------------------------------------------------------------------------
+// GitHub API helpers
+// ---------------------------------------------------------------------------
+
+function apiRequest(path, token) {
+  return new Promise((resolve, reject) => {
+    const options = {
+      hostname: "api.github.com",
+      path,
+      method: "GET",
+      headers: {
+        Authorization: `Bearer ${token}`,
+        Accept: "application/vnd.github+json",
+        "User-Agent": "oversized-issue-split-suggester-bot",
+        "X-GitHub-Api-Version": "2022-11-28",
+      },
+    };
+    const req = https.request(options, (res) => {
+      let raw = "";
+      res.on("data", (c) => (raw += c));
+      res.on("end", () =>
+        resolve({ status: res.statusCode, body: raw ? JSON.parse(raw) : {} }),
+      );
+    });
+    req.on("error", reject);
+    req.end();
+  });
+}
+
+async function fetchOpenIssues(repo, token) {
+  const issues = [];
+  let page = 1;
+  while (true) {
+    const { body } = await apiRequest(
+      `/repos/${repo}/issues?state=open&per_page=100&page=${page}`,
+      token,
+    );
+    if (!Array.isArray(body) || body.length === 0) break;
+    issues.push(...body.filter((i) => !i.pull_request));
+    if (body.length < 100) break;
+    page++;
+  }
+  return issues;
+}
+
+// ---------------------------------------------------------------------------
+// Heuristic helpers (exported via module.exports for testing)
+// ---------------------------------------------------------------------------
+
+/** Count acceptance-criteria bullet items in the body. */
+function countAcceptanceCriteria(body) {
+  if (!body) return 0;
+  // Match lines inside an "Acceptance Criteria" section
+  const acMatch = body.match(
+    /##\s*acceptance criteria[\s\S]*?(?=\n##|\s*$)/i,
+  );
+  if (!acMatch) return 0;
+  return (acMatch[0].match(/^\s*[-*]\s+\[[ x]\]/gim) || []).length;
+}
+
+/** Extract issue numbers from Blocked By / Dependencies sections. */
+function countBlockers(body) {
+  if (!body) return 0;
+  const blockMatch = body.match(
+    /##\s*(blocked by|dependencies|depends on|blockers)[\s\S]*?(?=\n##|\s*$)/i,
+  );
+  if (!blockMatch) return 0;
+  return (blockMatch[0].match(/(?<![a-zA-Z0-9_/-])#(\d+)/g) || []).length;
+}
+
+/** Count distinct track labels on the issue. */
+function countTracks(labels) {
+  return labels.filter((l) =>
+    l.name.toLowerCase().startsWith(TRACK_LABEL_PREFIX),
+  ).length;
+}
+
+/**
+ * Analyse a single issue and return a split suggestion record or null.
+ * @returns {{ number, title, url, triggers, suggestions } | null}
+ */
+function analyseIssue(issue) {
+  const body = issue.body || "";
+  const labels = issue.labels || [];
+  const labelNames = labels.map((l) => l.name);
+
+  const triggers = [];
+
+  // Heuristic 1 — body length
+  if (body.length > BODY_CHARS_THRESHOLD) {
+    triggers.push({
+      heuristic: "body_length",
+      detail: `Body is ${body.length} chars (threshold: ${BODY_CHARS_THRESHOLD})`,
+    });
+  }
+
+  // Heuristic 2 — acceptance-criteria count
+  const acCount = countAcceptanceCriteria(body);
+  if (acCount > AC_COUNT_THRESHOLD) {
+    triggers.push({
+      heuristic: "ac_count",
+      detail: `${acCount} acceptance criteria items (threshold: ${AC_COUNT_THRESHOLD})`,
+    });
+  }
+
+  // Heuristic 3 — multi-track labels
+  const trackCount = countTracks(labels);
+  if (trackCount > 1) {
+    const trackLabels = labelNames.filter((n) =>
+      n.toLowerCase().startsWith(TRACK_LABEL_PREFIX),
+    );
+    triggers.push({
+      heuristic: "multi_track",
+      detail: `Spans ${trackCount} tracks: ${trackLabels.join(", ")}`,
+    });
+  }
+
+  // Heuristic 4 — many blockers
+  const blockerCount = countBlockers(body);
+  if (blockerCount >= BLOCKERS_THRESHOLD) {
+    triggers.push({
+      heuristic: "blocker_count",
+      detail: `References ${blockerCount} blockers (threshold: ${BLOCKERS_THRESHOLD})`,
+    });
+  }
+
+  // Heuristic 5 — explicit oversized label
+  if (labelNames.some((n) => OVERSIZED_SIZE_LABELS.has(n.toLowerCase()))) {
+    const sizeLabel = labelNames.find((n) =>
+      OVERSIZED_SIZE_LABELS.has(n.toLowerCase()),
+    );
+    triggers.push({
+      heuristic: "size_label",
+      detail: `Carries label \`${sizeLabel}\``,
+    });
+  }
+
+  if (triggers.length === 0) return null;
+
+  const suggestions = buildSuggestions(triggers, body, acCount);
+
+  return {
+    number: issue.number,
+    title: issue.title,
+    url: issue.html_url,
+    triggers,
+    suggestions,
+  };
+}
+
+/**
+ * Produce human-readable split seam suggestions based on which heuristics fired.
+ */
+function buildSuggestions(triggers, body, acCount) {
+  const hints = [];
+  const heuristicNames = new Set(triggers.map((t) => t.heuristic));
+
+  if (heuristicNames.has("ac_count")) {
+    // Suggest splitting after the halfway point in the AC list
+    const half = Math.ceil(acCount / 2);
+    hints.push(
+      `Split acceptance criteria into two issues: first ${half} items in one issue, remaining in another.`,
+    );
+  }
+
+  if (heuristicNames.has("multi_track")) {
+    hints.push(
+      "Create one child issue per track label so each can be claimed independently.",
+    );
+  }
+
+  if (heuristicNames.has("blocker_count")) {
+    hints.push(
+      "Each blocker dependency may represent a natural seam — consider one issue per dependency chain.",
+    );
+  }
+
+  if (heuristicNames.has("body_length") && hints.length === 0) {
+    hints.push(
+      "Body is unusually long — identify the primary user-facing outcome and move secondary concerns to follow-up issues.",
+    );
+  }
+
+  if (heuristicNames.has("size_label") && hints.length === 0) {
+    hints.push(
+      "Labelled as large — break into a spike/research issue and one or more implementation issues.",
+    );
+  }
+
+  return hints;
+}
+
+// ---------------------------------------------------------------------------
+// Report
+// ---------------------------------------------------------------------------
+
+function buildTextReport(candidates, total) {
+  const lines = [
+    "=== Oversized Issue Split Suggester ===",
+    `Scanned:    ${total} open issues`,
+    `Candidates: ${candidates.length} issues flagged for potential split`,
+    "",
+  ];
+
+  if (candidates.length === 0) {
+    lines.push("✓ No oversized issues detected.");
+    return { output: lines.join("\n"), hasFindings: false };
+  }
+
+  for (const c of candidates) {
+    lines.push(`Issue #${c.number}: ${c.title}`);
+    lines.push(`  URL: ${c.url}`);
+    lines.push("  Triggers:");
+    for (const t of c.triggers) {
+      lines.push(`    • [${t.heuristic}] ${t.detail}`);
+    }
+    lines.push("  Suggested split seams:");
+    for (const s of c.suggestions) {
+      lines.push(`    → ${s}`);
+    }
+    lines.push("");
+  }
+
+  lines.push(
+    "NOTE: These are suggestions only. No issues have been modified.",
+  );
+  return { output: lines.join("\n"), hasFindings: true };
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+async function main() {
+  const token = process.env.GITHUB_TOKEN;
+  const repo = process.env.GITHUB_REPO;
+
+  if (!token || !repo) {
+    console.error("Missing required env vars: GITHUB_TOKEN, GITHUB_REPO");
+    process.exit(1);
+  }
+
+  console.log(`Scanning open issues in ${repo} for split candidates…`);
+
+  const issues = await fetchOpenIssues(repo, token);
+  console.log(`Found ${issues.length} open issues`);
+
+  const candidates = issues
+    .map((i) => analyseIssue(i))
+    .filter(Boolean);
+
+  if (OUTPUT_JSON) {
+    console.log(JSON.stringify({ scanned: issues.length, candidates }, null, 2));
+    return;
+  }
+
+  const { output, hasFindings } = buildTextReport(candidates, issues.length);
+  console.log("\n" + output);
+
+  if (hasFindings && !DRY_RUN) {
+    process.exit(1);
+  }
+}
+
+if (require.main === module) {
+  main().catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });
+}
+
+module.exports = {
+  countAcceptanceCriteria,
+  countBlockers,
+  countTracks,
+  analyseIssue,
+  buildSuggestions,
+};

--- a/scripts/oversized-issue-split-suggester.test.js
+++ b/scripts/oversized-issue-split-suggester.test.js
@@ -1,0 +1,126 @@
+const assert = require("node:assert/strict");
+const test = require("node:test");
+const {
+  countAcceptanceCriteria,
+  countBlockers,
+  countTracks,
+  analyseIssue,
+} = require("./oversized-issue-split-suggester.js");
+
+// ---------------------------------------------------------------------------
+// countAcceptanceCriteria
+// ---------------------------------------------------------------------------
+
+test("returns 0 when no AC section", () => {
+  assert.equal(countAcceptanceCriteria("## Description\nsome text"), 0);
+});
+
+test("counts AC checkbox items", () => {
+  const body = `## Acceptance Criteria\n- [ ] do A\n- [ ] do B\n- [x] do C\n## Notes\nend`;
+  assert.equal(countAcceptanceCriteria(body), 3);
+});
+
+test("returns 0 for null/empty body", () => {
+  assert.equal(countAcceptanceCriteria(""), 0);
+  assert.equal(countAcceptanceCriteria(null), 0);
+});
+
+// ---------------------------------------------------------------------------
+// countBlockers
+// ---------------------------------------------------------------------------
+
+test("returns 0 when no blocked-by section", () => {
+  assert.equal(countBlockers("## Description\nno blockers"), 0);
+});
+
+test("counts issue refs in Blocked By section", () => {
+  const body = `## Blocked By\n- #10\n- #20\n- #30\n## Next\nend`;
+  assert.equal(countBlockers(body), 3);
+});
+
+// ---------------------------------------------------------------------------
+// countTracks
+// ---------------------------------------------------------------------------
+
+test("returns 0 when no track labels", () => {
+  const labels = [{ name: "bug" }, { name: "enhancement" }];
+  assert.equal(countTracks(labels), 0);
+});
+
+test("counts track labels correctly", () => {
+  const labels = [
+    { name: "track:FE" },
+    { name: "track:BE" },
+    { name: "bug" },
+  ];
+  assert.equal(countTracks(labels), 2);
+});
+
+// ---------------------------------------------------------------------------
+// analyseIssue
+// ---------------------------------------------------------------------------
+
+test("returns null for a normal small issue", () => {
+  const issue = {
+    number: 1,
+    title: "Fix typo",
+    html_url: "https://github.com/org/repo/issues/1",
+    body: "Just a small fix.",
+    labels: [{ name: "bug" }],
+  };
+  assert.equal(analyseIssue(issue), null);
+});
+
+test("flags issue with oversized size label", () => {
+  const issue = {
+    number: 2,
+    title: "Big feature",
+    html_url: "https://github.com/org/repo/issues/2",
+    body: "Some body text.",
+    labels: [{ name: "size:L" }],
+  };
+  const result = analyseIssue(issue);
+  assert.ok(result);
+  assert.ok(result.triggers.some((t) => t.heuristic === "size_label"));
+});
+
+test("flags issue with too many AC items", () => {
+  const acs = Array.from({ length: 7 }, (_, i) => `- [ ] item ${i}`).join("\n");
+  const body = `## Acceptance Criteria\n${acs}\n## Notes\ndone`;
+  const issue = {
+    number: 3,
+    title: "Big task",
+    html_url: "https://github.com/org/repo/issues/3",
+    body,
+    labels: [],
+  };
+  const result = analyseIssue(issue);
+  assert.ok(result);
+  assert.ok(result.triggers.some((t) => t.heuristic === "ac_count"));
+});
+
+test("flags issue spanning multiple tracks", () => {
+  const issue = {
+    number: 4,
+    title: "Cross-track work",
+    html_url: "https://github.com/org/repo/issues/4",
+    body: "some text",
+    labels: [{ name: "track:FE" }, { name: "track:BE" }],
+  };
+  const result = analyseIssue(issue);
+  assert.ok(result);
+  assert.ok(result.triggers.some((t) => t.heuristic === "multi_track"));
+});
+
+test("includes suggestions for all triggered heuristics", () => {
+  const issue = {
+    number: 5,
+    title: "Very large",
+    html_url: "https://github.com/org/repo/issues/5",
+    body: "x".repeat(2000),
+    labels: [{ name: "size:XL" }],
+  };
+  const result = analyseIssue(issue);
+  assert.ok(result);
+  assert.ok(result.suggestions.length > 0);
+});


### PR DESCRIPTION
## Summary

Adds a script that scans all open issues for signs of scope creep and outputs suggested split seams — without mutating any GitHub issue.

## Changes

- **`scripts/oversized-issue-split-suggester.js`** — five heuristics: body length, AC item count, multi-track labels, blocker count, explicit size label; tunable via env vars; supports `OUTPUT_JSON` and `DRY_RUN`
- **`scripts/oversized-issue-split-suggester.test.js`** — 12 unit tests (12/12 pass)
- **`.github/workflows/oversized-issue-split-suggester.yml`** — weekly Monday 07:00 UTC cron + `workflow_dispatch`; defaults to `DRY_RUN=true` (informational, never fails CI)
- **`docs/wave/OVERSIZED_ISSUE_SPLIT_SUGGESTER.md`** — heuristic table, threshold reference, output example, schedule docs

## Validation

```
node --test scripts/oversized-issue-split-suggester.test.js
# ✔ 12/12 tests pass
```

Closes #863