### PR TITLE
feat(AI/AUTOMATION-210): generate reviewer load heatmaps by track label and update activity

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,7 @@ permissions:
 jobs:
   lockfile-guard:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - uses: actions/checkout@v4
       - name: Check frontend lockfile is in sync with package.json

--- a/.github/workflows/reviewer-load-heatmap.yml
+++ b/.github/workflows/reviewer-load-heatmap.yml
@@ -36,7 +36,7 @@ jobs:
 
       - name: Generate reviewer load heatmap
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ github.token }}
           GITHUB_REPO: ${{ github.repository }}
           LOOKBACK_DAYS: ${{ github.event.inputs.lookback_days || '30' }}
           OUTPUT_JSON: ${{ github.event.inputs.output_json || 'false' }}

--- a/.github/workflows/reviewer-load-heatmap.yml
+++ b/.github/workflows/reviewer-load-heatmap.yml
@@ -1,0 +1,43 @@
+name: Reviewer Load Heatmap
+
+on:
+  schedule:
+    - cron: "0 8 * * 1" # Every Monday at 08:00 UTC
+  workflow_dispatch:
+    inputs:
+      lookback_days:
+        description: "Activity window in days (default: 30)"
+        required: false
+        default: "30"
+      output_json:
+        description: "Emit JSON output (true/false)"
+        required: false
+        default: "false"
+
+permissions:
+  issues: read
+  pull-requests: read
+  contents: read
+
+jobs:
+  heatmap:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Run unit tests
+        run: node --test scripts/reviewer-load-heatmap.test.js
+
+      - name: Generate reviewer load heatmap
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPO: ${{ github.repository }}
+          LOOKBACK_DAYS: ${{ github.event.inputs.lookback_days || '30' }}
+          OUTPUT_JSON: ${{ github.event.inputs.output_json || 'false' }}
+        run: node scripts/reviewer-load-heatmap.js

--- a/docs/wave/REVIEWER_LOAD_HEATMAP.md
+++ b/docs/wave/REVIEWER_LOAD_HEATMAP.md
@@ -1,0 +1,68 @@
+# Reviewer Load Heatmap
+
+**Script:** `scripts/reviewer-load-heatmap.js`
+**Workflow:** `.github/workflows/reviewer-load-heatmap.yml`
+
+## Purpose
+
+Generates a visual heatmap of reviewer and maintainer workload grouped by
+track label, based on open PR review requests and open issue assignments.
+Helps maintainers spot overloaded contributors at a glance and rebalance
+assignments proactively.
+
+## How it works
+
+1. Fetches all open pull requests and open issues from the repo.
+2. Filters to items updated within the `LOOKBACK_DAYS` activity window (default: 30 days).
+3. Groups contributors by track label (`track:*`). Items with no track label land in `UNTRACKED`.
+4. For each track, shows each contributor's PR review count, issue assignment count, and a heat symbol.
+
+## Heat legend
+
+| Symbol | Meaning |
+|--------|---------|
+| `░░`   | No load |
+| `▒▒`   | Light (1–2) |
+| `▓▓`   | Medium (3–5) |
+| `██`   | Heavy (6+) — consider rebalancing |
+
+## Running locally
+
+```bash
+GITHUB_TOKEN=<pat> GITHUB_REPO=owner/repo node scripts/reviewer-load-heatmap.js
+```
+
+Set `LOOKBACK_DAYS=7` for a tighter window, or `OUTPUT_JSON=true` for
+machine-readable output suitable for dashboards or further tooling.
+
+## Example output
+
+```
+=== Reviewer Load Heatmap ===
+Window: last 30 days
+Tracks: 3
+
+Legend:  ░░ none   ▒▒ light (1-2)   ▓▓ medium (3-5)   ██ heavy (6+)
+
+── AI/AUTOMATION ──────────────────────────────
+  Contributor               Heat   PRs    Issues   Total
+  @automation-lead          ██     5      3        8
+  @docs-reviewer            ▒▒     1      1        2
+
+── FE ──────────────────────────────
+  Contributor               Heat   PRs    Issues   Total
+  @fe-maintainer            ▓▓     3      2        5
+```
+
+## Schedule
+
+Runs every Monday at **08:00 UTC** and on-demand via `workflow_dispatch`.
+The `lookback_days` input allows ad-hoc narrower windows for sprint reviews.
+
+## Interpreting and acting on the report
+
+- **██ heavy** reviewers: check whether PRs can be redistributed or whether
+  the contributor needs bandwidth relief.
+- **UNTRACKED** items: issues or PRs missing a `track:*` label — add labels
+  for accurate routing.
+- Compare week-over-week runs to identify sustained overload patterns.

--- a/scripts/reviewer-load-heatmap.js
+++ b/scripts/reviewer-load-heatmap.js
@@ -1,0 +1,240 @@
+#!/usr/bin/env node
+/**
+ * Reviewer Load Heatmap (AI/AUTOMATION-210)
+ *
+ * Generates a text/JSON heatmap of reviewer and maintainer load grouped by
+ * track label and recent update activity.  Gives maintainers an at-a-glance
+ * view of who is overloaded so they can rebalance assignments.
+ *
+ * Data sources:
+ *   - Open pull requests (requested_reviewers + review_requests)
+ *   - Open issues (assignees) labelled with a track:* label
+ *   - Both filtered to the configurable LOOKBACK_DAYS activity window
+ *
+ * Usage:
+ *   node scripts/reviewer-load-heatmap.js
+ *
+ * Required env vars:
+ *   GITHUB_TOKEN  - token with repo read permissions
+ *   GITHUB_REPO   - owner/repo
+ *
+ * Optional env vars:
+ *   LOOKBACK_DAYS  - activity window in days (default: 30)
+ *   OUTPUT_JSON    - "true" for machine-readable JSON
+ */
+
+"use strict";
+
+const https = require("https");
+
+// ---------------------------------------------------------------------------
+// Config
+// ---------------------------------------------------------------------------
+
+const LOOKBACK_DAYS = parseInt(process.env.LOOKBACK_DAYS || "30", 10);
+const OUTPUT_JSON = process.env.OUTPUT_JSON === "true";
+const TRACK_PREFIX = "track:";
+
+// ---------------------------------------------------------------------------
+// GitHub API helpers
+// ---------------------------------------------------------------------------
+
+function apiRequest(path, token) {
+  return new Promise((resolve, reject) => {
+    const opts = {
+      hostname: "api.github.com",
+      path,
+      method: "GET",
+      headers: {
+        Authorization: `Bearer ${token}`,
+        Accept: "application/vnd.github+json",
+        "User-Agent": "reviewer-load-heatmap-bot",
+        "X-GitHub-Api-Version": "2022-11-28",
+      },
+    };
+    const req = https.request(opts, (res) => {
+      let raw = "";
+      res.on("data", (c) => (raw += c));
+      res.on("end", () =>
+        resolve({ status: res.statusCode, body: raw ? JSON.parse(raw) : {} }),
+      );
+    });
+    req.on("error", reject);
+    req.end();
+  });
+}
+
+async function paginate(path, token) {
+  const items = [];
+  let page = 1;
+  while (true) {
+    const sep = path.includes("?") ? "&" : "?";
+    const { body } = await apiRequest(
+      `${path}${sep}per_page=100&page=${page}`,
+      token,
+    );
+    if (!Array.isArray(body) || body.length === 0) break;
+    items.push(...body);
+    if (body.length < 100) break;
+    page++;
+  }
+  return items;
+}
+
+// ---------------------------------------------------------------------------
+// Data collection helpers (exported for unit tests)
+// ---------------------------------------------------------------------------
+
+/** Extract the first track label from a labels array, or "untracked". */
+function detectTrack(labels) {
+  const found = labels.find((l) =>
+    l.name.toLowerCase().startsWith(TRACK_PREFIX),
+  );
+  return found ? found.name.slice(TRACK_PREFIX.length).toUpperCase() : "UNTRACKED";
+}
+
+/**
+ * Returns true if the item was updated within the lookback window.
+ * @param {string} updatedAt  - ISO 8601 date string
+ * @param {number} days
+ */
+function isRecent(updatedAt, days) {
+  const cutoff = Date.now() - days * 24 * 60 * 60 * 1000;
+  return new Date(updatedAt).getTime() >= cutoff;
+}
+
+/**
+ * Build a load map from open PRs.
+ * Shape: { [track]: { [login]: { prs: number, issues: number } } }
+ */
+function buildLoadMap(prs, issues, lookbackDays) {
+  // map[track][login] = { prs, issues }
+  const map = {};
+
+  const ensure = (track, login) => {
+    if (!map[track]) map[track] = {};
+    if (!map[track][login]) map[track][login] = { prs: 0, issues: 0 };
+  };
+
+  for (const pr of prs) {
+    if (!isRecent(pr.updated_at, lookbackDays)) continue;
+    const track = detectTrack(pr.labels || []);
+    for (const r of pr.requested_reviewers || []) {
+      ensure(track, r.login);
+      map[track][r.login].prs += 1;
+    }
+  }
+
+  for (const issue of issues) {
+    if (!isRecent(issue.updated_at, lookbackDays)) continue;
+    if (issue.pull_request) continue; // skip PRs returned by issues endpoint
+    const track = detectTrack(issue.labels || []);
+    for (const a of issue.assignees || []) {
+      ensure(track, a.login);
+      map[track][a.login].issues += 1;
+    }
+  }
+
+  return map;
+}
+
+/** Sum total load (prs + issues) for a contributor entry. */
+function totalLoad(entry) {
+  return entry.prs + entry.issues;
+}
+
+// ---------------------------------------------------------------------------
+// Rendering
+// ---------------------------------------------------------------------------
+
+/** Map a total load number to a heat symbol for quick scanning. */
+function heatSymbol(total) {
+  if (total === 0) return "░░"; // none
+  if (total <= 2) return "▒▒"; // light
+  if (total <= 5) return "▓▓"; // medium
+  return "██"; // heavy
+}
+
+function buildTextReport(map, lookbackDays) {
+  const tracks = Object.keys(map).sort();
+  const lines = [
+    "=== Reviewer Load Heatmap ===",
+    `Window: last ${lookbackDays} days`,
+    `Tracks: ${tracks.length || 0}`,
+    "",
+    "Legend:  ░░ none   ▒▒ light (1-2)   ▓▓ medium (3-5)   ██ heavy (6+)",
+    "",
+  ];
+
+  if (tracks.length === 0) {
+    lines.push("No open PR review assignments or issue assignments found.");
+    return lines.join("\n");
+  }
+
+  for (const track of tracks) {
+    lines.push(`── ${track} ──────────────────────────────`);
+    const contributors = Object.entries(map[track]).sort(
+      (a, b) => totalLoad(b[1]) - totalLoad(a[1]),
+    );
+
+    if (contributors.length === 0) {
+      lines.push("  (no active contributors)");
+    } else {
+      lines.push(
+        `  ${"Contributor".padEnd(25)} ${"Heat".padEnd(6)} PRs   Issues  Total`,
+      );
+      for (const [login, counts] of contributors) {
+        const tot = totalLoad(counts);
+        lines.push(
+          `  ${("@" + login).padEnd(25)} ${heatSymbol(tot).padEnd(6)} ${String(counts.prs).padEnd(6)} ${String(counts.issues).padEnd(8)} ${tot}`,
+        );
+      }
+    }
+    lines.push("");
+  }
+
+  return lines.join("\n");
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+async function main() {
+  const token = process.env.GITHUB_TOKEN;
+  const repo = process.env.GITHUB_REPO;
+
+  if (!token || !repo) {
+    console.error("Missing required env vars: GITHUB_TOKEN, GITHUB_REPO");
+    process.exit(1);
+  }
+
+  console.log(
+    `Building reviewer load heatmap for ${repo} (last ${LOOKBACK_DAYS} days)…`,
+  );
+
+  const [prs, issues] = await Promise.all([
+    paginate(`/repos/${repo}/pulls?state=open`, token),
+    paginate(`/repos/${repo}/issues?state=open`, token),
+  ]);
+
+  console.log(`Open PRs: ${prs.length}  Open issues: ${issues.length}`);
+
+  const map = buildLoadMap(prs, issues, LOOKBACK_DAYS);
+
+  if (OUTPUT_JSON) {
+    console.log(JSON.stringify({ window_days: LOOKBACK_DAYS, tracks: map }, null, 2));
+    return;
+  }
+
+  console.log("\n" + buildTextReport(map, LOOKBACK_DAYS));
+}
+
+if (require.main === module) {
+  main().catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });
+}
+
+module.exports = { detectTrack, isRecent, buildLoadMap, totalLoad, heatSymbol };

--- a/scripts/reviewer-load-heatmap.test.js
+++ b/scripts/reviewer-load-heatmap.test.js
@@ -1,0 +1,114 @@
+const assert = require("node:assert/strict");
+const test = require("node:test");
+const {
+  detectTrack,
+  isRecent,
+  buildLoadMap,
+  totalLoad,
+  heatSymbol,
+} = require("./reviewer-load-heatmap.js");
+
+// ---------------------------------------------------------------------------
+// detectTrack
+// ---------------------------------------------------------------------------
+
+test("returns UNTRACKED when no track label", () => {
+  assert.equal(detectTrack([{ name: "bug" }, { name: "size:S" }]), "UNTRACKED");
+});
+
+test("extracts track name from label", () => {
+  assert.equal(
+    detectTrack([{ name: "track:FE" }, { name: "bug" }]),
+    "FE",
+  );
+});
+
+test("track detection is case-insensitive", () => {
+  assert.equal(detectTrack([{ name: "Track:AI/AUTOMATION" }]), "AI/AUTOMATION");
+});
+
+// ---------------------------------------------------------------------------
+// isRecent
+// ---------------------------------------------------------------------------
+
+test("returns true for an update today", () => {
+  assert.equal(isRecent(new Date().toISOString(), 30), true);
+});
+
+test("returns false for an update 60 days ago with 30-day window", () => {
+  const old = new Date(Date.now() - 60 * 24 * 60 * 60 * 1000).toISOString();
+  assert.equal(isRecent(old, 30), false);
+});
+
+// ---------------------------------------------------------------------------
+// buildLoadMap
+// ---------------------------------------------------------------------------
+
+const NOW = new Date().toISOString();
+
+test("counts PR reviewer in correct track", () => {
+  const prs = [
+    {
+      updated_at: NOW,
+      labels: [{ name: "track:FE" }],
+      requested_reviewers: [{ login: "alice" }],
+    },
+  ];
+  const map = buildLoadMap(prs, [], 30);
+  assert.equal(map["FE"]["alice"].prs, 1);
+  assert.equal(map["FE"]["alice"].issues, 0);
+});
+
+test("counts issue assignee in correct track", () => {
+  const issues = [
+    {
+      updated_at: NOW,
+      labels: [{ name: "track:BE" }],
+      assignees: [{ login: "bob" }],
+    },
+  ];
+  const map = buildLoadMap([], issues, 30);
+  assert.equal(map["BE"]["bob"].issues, 1);
+  assert.equal(map["BE"]["bob"].prs, 0);
+});
+
+test("ignores items outside lookback window", () => {
+  const old = new Date(Date.now() - 60 * 24 * 60 * 60 * 1000).toISOString();
+  const prs = [
+    {
+      updated_at: old,
+      labels: [{ name: "track:FE" }],
+      requested_reviewers: [{ login: "carol" }],
+    },
+  ];
+  const map = buildLoadMap(prs, [], 30);
+  assert.equal(Object.keys(map).length, 0);
+});
+
+test("skips pull_request entries in issues list", () => {
+  const issues = [
+    {
+      updated_at: NOW,
+      labels: [{ name: "track:FE" }],
+      assignees: [{ login: "dave" }],
+      pull_request: {},
+    },
+  ];
+  const map = buildLoadMap([], issues, 30);
+  assert.equal(Object.keys(map).length, 0);
+});
+
+// ---------------------------------------------------------------------------
+// totalLoad & heatSymbol
+// ---------------------------------------------------------------------------
+
+test("totalLoad sums prs and issues", () => {
+  assert.equal(totalLoad({ prs: 3, issues: 2 }), 5);
+});
+
+test("heatSymbol returns correct tier", () => {
+  assert.equal(heatSymbol(0), "░░");
+  assert.equal(heatSymbol(2), "▒▒");
+  assert.equal(heatSymbol(4), "▓▓");
+  assert.equal(heatSymbol(7), "██");
+});


### PR DESCRIPTION
## Summary

Adds a script that renders an ASCII heatmap of reviewer and maintainer workload grouped by `track:*` label, derived from open PR review requests and open issue assignments within a configurable activity window.

## Changes

- **`scripts/reviewer-load-heatmap.js`** — fetches open PRs + issues, groups by track, renders a four-tier heat legend (░░▒▒▓▓██); configurable `LOOKBACK_DAYS`; supports `OUTPUT_JSON`
- **`scripts/reviewer-load-heatmap.test.js`** — 11 unit tests (11/11 pass)
- **`.github/workflows/reviewer-load-heatmap.yml`** — weekly Monday 08:00 UTC cron + `workflow_dispatch` with `lookback_days` input
- **`docs/wave/REVIEWER_LOAD_HEATMAP.md`** — heat legend, output example, interpretation guide

## Validation

```
node --test scripts/reviewer-load-heatmap.test.js
# ✔ 11/11 tests pass
```

Closes #864