### PR TITLE
feat(AI/AUTOMATION-211): compile release-note drafts from merged PR labels and paths

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,7 @@ permissions:
 jobs:
   lockfile-guard:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - uses: actions/checkout@v4
       - name: Check frontend lockfile is in sync with package.json

--- a/.github/workflows/compile-release-notes.yml
+++ b/.github/workflows/compile-release-notes.yml
@@ -40,7 +40,7 @@ jobs:
 
       - name: Compile release-note draft
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ github.token }}
           GITHUB_REPO: ${{ github.repository }}
           SINCE_TAG: ${{ github.event.inputs.since_tag || github.event.ref }}
           TARGET_BRANCH: ${{ github.event.inputs.target_branch || 'main' }}

--- a/.github/workflows/compile-release-notes.yml
+++ b/.github/workflows/compile-release-notes.yml
@@ -1,0 +1,48 @@
+name: Compile Release Notes Draft
+
+on:
+  workflow_dispatch:
+    inputs:
+      since_tag:
+        description: "Tag, SHA, or ISO date to use as start of range (leave blank for last 30 days)"
+        required: false
+        default: ""
+      target_branch:
+        description: "Branch whose merged PRs to include (default: main)"
+        required: false
+        default: "main"
+      output_json:
+        description: "Emit JSON output (true/false)"
+        required: false
+        default: "false"
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  compile-release-notes:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Run unit tests
+        run: node --test scripts/compile-release-notes.test.js
+
+      - name: Compile release-note draft
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPO: ${{ github.repository }}
+          SINCE_TAG: ${{ github.event.inputs.since_tag || github.event.ref }}
+          TARGET_BRANCH: ${{ github.event.inputs.target_branch || 'main' }}
+          OUTPUT_JSON: ${{ github.event.inputs.output_json || 'false' }}
+        run: node scripts/compile-release-notes.js

--- a/docs/wave/RELEASE_NOTES_COMPILER.md
+++ b/docs/wave/RELEASE_NOTES_COMPILER.md
@@ -1,0 +1,90 @@
+# Release-Note Draft Compiler
+
+**Script:** `scripts/compile-release-notes.js`
+**Workflow:** `.github/workflows/compile-release-notes.yml`
+
+## Purpose
+
+Automates the first draft of a release note by fetching merged pull requests,
+classifying them by label and changed file path, and producing a structured
+Markdown document that maintainers can edit into a final human-facing summary.
+
+## How it works
+
+1. Fetches all closed PRs merged into `TARGET_BRANCH` since `SINCE_TAG` (or last 30 days).
+2. Classifies each PR into a release-note category based on its labels.
+3. Enriches each entry with the affected areas derived from changed file paths.
+4. Emits a structured Markdown draft (or JSON with `OUTPUT_JSON=true`).
+
+## Label → Category mapping
+
+| Label pattern | Category |
+|---|---|
+| `breaking` | ⚠️ Breaking Changes |
+| `feat`, `feature`, `enhancement` | ✨ New Features |
+| `fix`, `bug` | 🐛 Bug Fixes |
+| `doc`, `docs` | 📖 Documentation |
+| `tool`, `automation`, `ci`, `workflow`, `script` | 🔧 Tooling & Automation |
+| `chore`, `refactor`, `style`, `cleanup` | 🧹 Chores & Refactors |
+| anything else | 🔀 Other |
+
+## Path → Area mapping
+
+| Path prefix | Area |
+|---|---|
+| `frontend/` | Frontend |
+| `backend/` | Backend |
+| `soroban/` | Onchain / Soroban |
+| `scripts/` | Tooling / Automation |
+| `docs/` | Documentation |
+| `.github/` | CI / Workflows |
+| `onchain/` | Onchain (legacy) |
+| other | General |
+
+## Running locally
+
+```bash
+# Last 30 days
+GITHUB_TOKEN=<pat> GITHUB_REPO=owner/repo node scripts/compile-release-notes.js
+
+# Since a specific tag
+GITHUB_TOKEN=<pat> GITHUB_REPO=owner/repo SINCE_TAG=v1.2.0 node scripts/compile-release-notes.js
+
+# JSON output for tooling
+OUTPUT_JSON=true GITHUB_TOKEN=<pat> GITHUB_REPO=owner/repo node scripts/compile-release-notes.js
+```
+
+## Triggering the workflow
+
+The workflow runs automatically on `v*` tag pushes and can be triggered manually
+via `workflow_dispatch` with optional `since_tag`, `target_branch`, and
+`output_json` inputs.
+
+## Example output
+
+```markdown
+# Release Notes Draft
+
+> **Auto-generated** on 2026-06-23 from merged PRs since `v1.2.0`.
+> Edit this document before publishing.
+
+## ✨ New Features
+
+- **[#102](https://github.com/org/repo/pull/102)** Add Soroban wallet integration _(Frontend, Onchain / Soroban)_
+
+## 🐛 Bug Fixes
+
+- **[#99](https://github.com/org/repo/pull/99)** Fix score persistence on refresh _(Backend)_
+
+## 🔧 Tooling & Automation
+
+- **[#101](https://github.com/org/repo/pull/101)** Add reviewer load heatmap script _(Tooling / Automation, CI / Workflows)_
+```
+
+## Editing the draft
+
+1. Copy the output to `CHANGELOG.md` or a new release notes file.
+2. Remove low-signal entries (pure chores, trivial refactors).
+3. Rewrite PR titles into user-facing language where needed.
+4. Add a summary paragraph at the top.
+5. Publish to GitHub Releases or the project changelog.

--- a/scripts/compile-release-notes.js
+++ b/scripts/compile-release-notes.js
@@ -1,0 +1,302 @@
+#!/usr/bin/env node
+/**
+ * Release-Note Draft Compiler (AI/AUTOMATION-211)
+ *
+ * Fetches merged pull requests since a base ref (tag or SHA), groups them by
+ * label (feature, fix, docs, chore, breaking, etc.), and emits a structured
+ * draft release-note document that maintainers can edit into a human-facing
+ * release summary.
+ *
+ * Changed-path buckets are derived from PR file paths:
+ *   frontend/  → Frontend
+ *   backend/   → Backend
+ *   soroban/   → Onchain / Soroban
+ *   scripts/   → Tooling / Automation
+ *   docs/      → Documentation
+ *   .github/   → CI / Workflows
+ *   other      → General
+ *
+ * Usage:
+ *   node scripts/compile-release-notes.js
+ *
+ * Required env vars:
+ *   GITHUB_TOKEN   - token with repo read permissions
+ *   GITHUB_REPO    - owner/repo
+ *
+ * Optional env vars:
+ *   SINCE_TAG      - tag or ISO date; defaults to last 30 days
+ *   OUTPUT_JSON    - "true" for machine-readable JSON
+ *   TARGET_BRANCH  - branch to filter merged PRs (default: main)
+ */
+
+"use strict";
+
+const https = require("https");
+
+// ---------------------------------------------------------------------------
+// Config
+// ---------------------------------------------------------------------------
+
+const OUTPUT_JSON = process.env.OUTPUT_JSON === "true";
+const TARGET_BRANCH = process.env.TARGET_BRANCH || "main";
+const SINCE_TAG = process.env.SINCE_TAG || null;
+
+// ---------------------------------------------------------------------------
+// Label → release-note category mapping (exported for tests)
+// ---------------------------------------------------------------------------
+
+const LABEL_CATEGORIES = [
+  { category: "⚠️ Breaking Changes", patterns: [/breaking/i] },
+  { category: "✨ New Features", patterns: [/feat|feature|enhancement/i] },
+  { category: "🐛 Bug Fixes", patterns: [/fix|bug/i] },
+  { category: "📖 Documentation", patterns: [/doc|docs/i] },
+  { category: "🔧 Tooling & Automation", patterns: [/tool|automation|ci|workflow|script/i] },
+  { category: "🧹 Chores & Refactors", patterns: [/chore|refactor|style|cleanup/i] },
+];
+
+const DEFAULT_CATEGORY = "🔀 Other";
+
+// ---------------------------------------------------------------------------
+// Path → area mapping
+// ---------------------------------------------------------------------------
+
+const PATH_AREAS = [
+  { area: "Frontend", prefix: "frontend/" },
+  { area: "Backend", prefix: "backend/" },
+  { area: "Onchain / Soroban", prefix: "soroban/" },
+  { area: "Tooling / Automation", prefix: "scripts/" },
+  { area: "Documentation", prefix: "docs/" },
+  { area: "CI / Workflows", prefix: ".github/" },
+  { area: "Onchain (legacy)", prefix: "onchain/" },
+];
+
+// ---------------------------------------------------------------------------
+// GitHub API helpers
+// ---------------------------------------------------------------------------
+
+function apiRequest(path, token) {
+  return new Promise((resolve, reject) => {
+    const opts = {
+      hostname: "api.github.com",
+      path,
+      method: "GET",
+      headers: {
+        Authorization: `Bearer ${token}`,
+        Accept: "application/vnd.github+json",
+        "User-Agent": "compile-release-notes-bot",
+        "X-GitHub-Api-Version": "2022-11-28",
+      },
+    };
+    const req = https.request(opts, (res) => {
+      let raw = "";
+      res.on("data", (c) => (raw += c));
+      res.on("end", () =>
+        resolve({ status: res.statusCode, body: raw ? JSON.parse(raw) : {} }),
+      );
+    });
+    req.on("error", reject);
+    req.end();
+  });
+}
+
+async function paginate(path, token) {
+  const items = [];
+  let page = 1;
+  while (true) {
+    const sep = path.includes("?") ? "&" : "?";
+    const { body } = await apiRequest(
+      `${path}${sep}per_page=100&page=${page}`,
+      token,
+    );
+    if (!Array.isArray(body) || body.length === 0) break;
+    items.push(...body);
+    if (body.length < 100) break;
+    page++;
+  }
+  return items;
+}
+
+/** Fetch changed file paths for a single PR. */
+async function fetchPRFiles(repo, prNumber, token) {
+  const files = await paginate(`/repos/${repo}/pulls/${prNumber}/files`, token);
+  return files.map((f) => f.filename);
+}
+
+// ---------------------------------------------------------------------------
+// Classification helpers (exported for unit tests)
+// ---------------------------------------------------------------------------
+
+/**
+ * Returns the release-note category for the first matching label, or DEFAULT_CATEGORY.
+ * @param {string[]} labelNames
+ */
+function classifyByLabels(labelNames) {
+  for (const { category, patterns } of LABEL_CATEGORIES) {
+    if (labelNames.some((l) => patterns.some((p) => p.test(l)))) {
+      return category;
+    }
+  }
+  return DEFAULT_CATEGORY;
+}
+
+/**
+ * Returns the set of affected areas derived from file paths.
+ * @param {string[]} paths
+ * @returns {string[]}
+ */
+function classifyPaths(paths) {
+  const areas = new Set();
+  for (const p of paths) {
+    const match = PATH_AREAS.find(({ prefix }) => p.startsWith(prefix));
+    areas.add(match ? match.area : "General");
+  }
+  return [...areas].sort();
+}
+
+// ---------------------------------------------------------------------------
+// Rendering
+// ---------------------------------------------------------------------------
+
+/**
+ * Build the draft release-note markdown.
+ * @param {{ category: string, prs: Array }[]} sections
+ * @param {string} since
+ * @param {string} repo
+ */
+function buildMarkdown(sections, since, repo) {
+  const today = new Date().toISOString().slice(0, 10);
+  const lines = [
+    `# Release Notes Draft`,
+    ``,
+    `> **Auto-generated** on ${today} from merged PRs since \`${since}\`.`,
+    `> Edit this document before publishing. Add context, remove noise, merge related items.`,
+    ``,
+  ];
+
+  let totalPRs = 0;
+  for (const { category, prs } of sections) {
+    if (prs.length === 0) continue;
+    lines.push(`## ${category}`, "");
+    for (const pr of prs) {
+      totalPRs++;
+      const areas = pr.areas.length ? ` _(${pr.areas.join(", ")})_` : "";
+      lines.push(
+        `- **[#${pr.number}](https://github.com/${repo}/pull/${pr.number})** ${pr.title}${areas}`,
+      );
+    }
+    lines.push("");
+  }
+
+  if (totalPRs === 0) {
+    lines.push("_No merged PRs found in this window._", "");
+  }
+
+  lines.push(
+    "---",
+    `_Generated by \`scripts/compile-release-notes.js\` · ${totalPRs} PR(s) included_`,
+  );
+
+  return lines.join("\n");
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+async function main() {
+  const token = process.env.GITHUB_TOKEN;
+  const repo = process.env.GITHUB_REPO;
+
+  if (!token || !repo) {
+    console.error("Missing required env vars: GITHUB_TOKEN, GITHUB_REPO");
+    process.exit(1);
+  }
+
+  // Determine since date
+  let sinceISO;
+  if (SINCE_TAG) {
+    // Try to resolve tag to a commit date
+    const { status, body } = await apiRequest(
+      `/repos/${repo}/git/ref/tags/${SINCE_TAG}`,
+      token,
+    );
+    if (status === 200) {
+      const commitSha = body.object.sha;
+      const { body: commitBody } = await apiRequest(
+        `/repos/${repo}/commits/${commitSha}`,
+        token,
+      );
+      sinceISO =
+        commitBody.commit?.committer?.date ||
+        new Date(Date.now() - 30 * 24 * 60 * 60 * 1000).toISOString();
+    } else {
+      // Treat as ISO date string directly
+      sinceISO = SINCE_TAG;
+    }
+  } else {
+    sinceISO = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000).toISOString();
+  }
+
+  const sinceLabel = SINCE_TAG || `last 30 days (since ${sinceISO.slice(0, 10)})`;
+  console.log(`Compiling release notes for ${repo} — ${sinceLabel}…`);
+
+  // Fetch merged PRs
+  const allPRs = await paginate(
+    `/repos/${repo}/pulls?state=closed&base=${TARGET_BRANCH}`,
+    token,
+  );
+
+  const mergedPRs = allPRs.filter(
+    (pr) => pr.merged_at && new Date(pr.merged_at) >= new Date(sinceISO),
+  );
+
+  console.log(`Found ${mergedPRs.length} merged PRs`);
+
+  // Enrich with file paths
+  const enriched = [];
+  for (const pr of mergedPRs) {
+    const labelNames = (pr.labels || []).map((l) => l.name);
+    const category = classifyByLabels(labelNames);
+    const files = await fetchPRFiles(repo, pr.number, token);
+    const areas = classifyPaths(files);
+
+    enriched.push({
+      number: pr.number,
+      title: pr.title,
+      mergedAt: pr.merged_at,
+      labels: labelNames,
+      category,
+      areas,
+    });
+  }
+
+  // Build category sections in defined order
+  const categoryOrder = [
+    ...LABEL_CATEGORIES.map((c) => c.category),
+    DEFAULT_CATEGORY,
+  ];
+
+  const sections = categoryOrder.map((cat) => ({
+    category: cat,
+    prs: enriched.filter((p) => p.category === cat),
+  }));
+
+  if (OUTPUT_JSON) {
+    console.log(
+      JSON.stringify({ since: sinceISO, total: mergedPRs.length, sections }, null, 2),
+    );
+    return;
+  }
+
+  const markdown = buildMarkdown(sections, sinceLabel, repo);
+  console.log("\n" + markdown);
+}
+
+if (require.main === module) {
+  main().catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });
+}
+
+module.exports = { classifyByLabels, classifyPaths, buildMarkdown, LABEL_CATEGORIES };

--- a/scripts/compile-release-notes.test.js
+++ b/scripts/compile-release-notes.test.js
@@ -1,0 +1,123 @@
+const assert = require("node:assert/strict");
+const test = require("node:test");
+const {
+  classifyByLabels,
+  classifyPaths,
+  buildMarkdown,
+} = require("./compile-release-notes.js");
+
+// ---------------------------------------------------------------------------
+// classifyByLabels
+// ---------------------------------------------------------------------------
+
+test("classifies 'feat' label as New Features", () => {
+  assert.match(classifyByLabels(["feat"]), /New Features/);
+});
+
+test("classifies 'Enhancement' label as New Features", () => {
+  assert.match(classifyByLabels(["Enhancement"]), /New Features/);
+});
+
+test("classifies 'bug' label as Bug Fixes", () => {
+  assert.match(classifyByLabels(["bug"]), /Bug Fixes/);
+});
+
+test("classifies 'fix' label as Bug Fixes", () => {
+  assert.match(classifyByLabels(["fix"]), /Bug Fixes/);
+});
+
+test("classifies 'docs' label as Documentation", () => {
+  assert.match(classifyByLabels(["docs"]), /Documentation/);
+});
+
+test("classifies 'breaking' label as Breaking Changes", () => {
+  assert.match(classifyByLabels(["breaking"]), /Breaking Changes/);
+});
+
+test("classifies 'chore' label as Chores", () => {
+  assert.match(classifyByLabels(["chore"]), /Chores/);
+});
+
+test("returns default category for unknown label", () => {
+  assert.equal(classifyByLabels(["random-label"]), "🔀 Other");
+});
+
+test("returns default category for empty labels", () => {
+  assert.equal(classifyByLabels([]), "🔀 Other");
+});
+
+// ---------------------------------------------------------------------------
+// classifyPaths
+// ---------------------------------------------------------------------------
+
+test("maps frontend/ path to Frontend area", () => {
+  assert.ok(classifyPaths(["frontend/src/App.tsx"]).includes("Frontend"));
+});
+
+test("maps backend/ path to Backend area", () => {
+  assert.ok(classifyPaths(["backend/src/main.ts"]).includes("Backend"));
+});
+
+test("maps soroban/ path to Onchain/Soroban area", () => {
+  assert.ok(
+    classifyPaths(["soroban/contracts/game.rs"]).some((a) =>
+      a.includes("Soroban"),
+    ),
+  );
+});
+
+test("maps scripts/ path to Tooling area", () => {
+  assert.ok(
+    classifyPaths(["scripts/foo.js"]).some((a) => a.includes("Tooling")),
+  );
+});
+
+test("maps .github/ path to CI/Workflows area", () => {
+  assert.ok(
+    classifyPaths([".github/workflows/ci.yml"]).some((a) => a.includes("CI")),
+  );
+});
+
+test("maps unknown path to General", () => {
+  assert.ok(classifyPaths(["random/file.txt"]).includes("General"));
+});
+
+test("returns multiple distinct areas for multi-path PR", () => {
+  const areas = classifyPaths(["frontend/App.tsx", "backend/main.ts"]);
+  assert.ok(areas.includes("Frontend"));
+  assert.ok(areas.includes("Backend"));
+});
+
+// ---------------------------------------------------------------------------
+// buildMarkdown
+// ---------------------------------------------------------------------------
+
+test("includes PR title and number in output", () => {
+  const sections = [
+    {
+      category: "✨ New Features",
+      prs: [
+        { number: 42, title: "Add dark mode", areas: ["Frontend"] },
+      ],
+    },
+  ];
+  const md = buildMarkdown(sections, "v1.0.0", "org/repo");
+  assert.match(md, /#42/);
+  assert.match(md, /Add dark mode/);
+});
+
+test("skips empty category sections", () => {
+  const sections = [
+    { category: "✨ New Features", prs: [] },
+    { category: "🐛 Bug Fixes", prs: [{ number: 1, title: "Fix crash", areas: [] }] },
+  ];
+  const md = buildMarkdown(sections, "v1.0.0", "org/repo");
+  assert.doesNotMatch(md, /## ✨ New Features/);
+  assert.match(md, /## 🐛 Bug Fixes/);
+});
+
+test("shows no-PRs message when all sections empty", () => {
+  const sections = [{ category: "✨ New Features", prs: [] }];
+  const md = buildMarkdown(sections, "v1.0.0", "org/repo");
+  assert.match(md, /No merged PRs found/);
+});


### PR DESCRIPTION
## Summary

Adds a script that compiles a structured Markdown release-note draft from merged PR metadata — grouped by label category and annotated with affected codebase areas derived from changed file paths.

## Changes

- **`scripts/compile-release-notes.js`** — fetches merged PRs since a configurable tag/date, classifies each into one of 7 categories via label patterns, maps changed file paths to 7 area buckets; emits editable Markdown or JSON; supports `SINCE_TAG`, `TARGET_BRANCH`, `OUTPUT_JSON`
- **`scripts/compile-release-notes.test.js`** — 19 unit tests covering label classification, path mapping, and markdown rendering (19/19 pass)
- **`.github/workflows/compile-release-notes.yml`** — auto-triggers on `v*` tag pushes + manual `workflow_dispatch` with `since_tag`, `target_branch`, `output_json` inputs
- **`docs/wave/RELEASE_NOTES_COMPILER.md`** — label→category table, path→area table, usage examples, output example, editing guide

## Validation

```
node --test scripts/compile-release-notes.test.js
# ✔ 19/19 tests pass
```

Closes #865