### PR TITLE
feat(frontend): skeleton system, a11y fixes, result card, wallet account-switch detection

### DIFF
--- a/frontend/src/components/LoginModal.tsx
+++ b/frontend/src/components/LoginModal.tsx
@@ -38,79 +38,97 @@ export function LoginForm({ closeModal }: ModalProps) {
     }
   };
 
+  const formId = isSignup ? 'signup-form' : 'login-form';
+
   return (
     <div className="min-w-[400px] px-2 max-w-md">
       <div
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={`${formId}-title`}
         className="rounded-3xl p-8 shadow-2xl"
         style={{
           background:
             'linear-gradient(135deg, #1a0b3d 0%, #2d1b69 50%, #1a0b3d 100%)',
         }}
       >
-        {/* Title */}
         <div className="flex justify-between">
-          <h1 className="text-4xl font-light text-white mb-12">
+          <h1 id={`${formId}-title`} className="text-4xl font-light text-white mb-12">
             {isSignup ? 'Sign Up' : 'Login'}
           </h1>
           <button
-            className="w-8 h-8 p-2 rounded-full bg-black items-center justify-center flex cursor-pointer border"
+            type="button"
+            aria-label="Close dialog"
+            className="w-8 h-8 p-2 rounded-full bg-black items-center justify-center flex cursor-pointer border focus:outline-none focus:ring-2 focus:ring-white/60"
             onClick={() => closeModal()}
           >
-            X
+            <span aria-hidden="true">✕</span>
           </button>
         </div>
-        {/* Error Message */}
+
         {error && (
-          <div className="mb-6 p-3 bg-red-500/20 border border-red-500/30 text-red-200 rounded-lg text-sm">
+          <div
+            role="alert"
+            aria-live="assertive"
+            className="mb-6 p-3 bg-red-500/20 border border-red-500/30 text-red-200 rounded-lg text-sm"
+          >
             {error}
           </div>
         )}
 
-        <form onSubmit={handleSubmit} className="space-y-6">
-          {/* Email input */}
+        <form id={formId} onSubmit={handleSubmit} className="space-y-6" noValidate>
           <div>
+            <label htmlFor="email" className="sr-only">Email address</label>
             <input
+              id="email"
               type="email"
               placeholder="Email Address"
+              autoComplete="email"
               value={formData.email}
               onChange={(e) =>
                 setFormData({ ...formData, email: e.target.value })
               }
               required
+              aria-required="true"
               className="h-14 bg-white/5 border-white/10 text-white placeholder:text-gray-400 rounded-xl focus:border-secondary focus:ring-secondary/20 w-full px-2"
             />
           </div>
 
-          {/* Username input (only for signup) */}
           {isSignup && (
             <div>
+              <label htmlFor="username" className="sr-only">Username</label>
               <input
+                id="username"
                 placeholder="Username"
+                autoComplete="username"
                 value={formData.username}
                 onChange={(e) =>
                   setFormData({ ...formData, username: e.target.value })
                 }
                 required
+                aria-required="true"
                 className="h-14 bg-white/5 border-white/10 text-white placeholder:text-gray-400 rounded-xl focus:border-secondary focus:ring-secondary/20 w-full px-2"
               />
             </div>
           )}
 
-          {/* Password input */}
           <div>
+            <label htmlFor="password" className="sr-only">Password</label>
             <input
+              id="password"
               type="password"
               placeholder="Password"
+              autoComplete={isSignup ? 'new-password' : 'current-password'}
               value={formData.password}
               onChange={(e) =>
                 setFormData({ ...formData, password: e.target.value })
               }
               required
+              aria-required="true"
               className="h-14 bg-white/5 border-white/10 text-white placeholder:text-gray-400 rounded-xl focus:border-secondary focus:ring-secondary/20 w-full px-2"
             />
           </div>
 
-          {/* Remember Me & Forgot Password (only for login) */}
           {!isSignup && (
             <div className="flex items-center justify-between">
               <div className="flex items-center space-x-2">
@@ -127,45 +145,41 @@ export function LoginForm({ closeModal }: ModalProps) {
               </div>
               <button
                 type="button"
-                className="text-white text-sm hover:text-purple-300 transition-colors"
+                className="text-white text-sm hover:text-purple-300 transition-colors focus:outline-none focus:underline"
               >
-                Forgot Password ?
+                Forgot Password?
               </button>
             </div>
           )}
 
-          {/* Login/Signup button */}
           <button
             type="submit"
             disabled={isLoading}
-            className="w-full px-2 h-14 text-lg font-medium rounded-xl transition-all duration-200"
+            aria-disabled={isLoading}
+            className="w-full px-2 h-14 text-lg font-medium rounded-xl transition-all duration-200 focus:outline-none focus:ring-2 focus:ring-purple-400"
             style={{
               background:
                 'linear-gradient(135deg, #8b5cf6 0%, #a855f7 50%, #9333ea 100%)',
             }}
           >
-            {isLoading ? 'Loading...' : isSignup ? 'Sign Up' : 'Login'}
+            {isLoading ? 'Loading…' : isSignup ? 'Sign Up' : 'Login'}
           </button>
 
-          {/* Switch between Login/Signup */}
           <div className="text-center">
             <span className="text-white text-sm">
-              {isSignup
-                ? 'Already have an account? '
-                : 'Already have an account? '}
+              {isSignup ? 'Already have an account? ' : "Don't have an account? "}
             </span>
             <button
               type="button"
               onClick={() => setIsSignup(!isSignup)}
-              className="text-purple-300 text-sm hover:text-purple-200 transition-colors underline"
+              className="text-purple-300 text-sm hover:text-purple-200 transition-colors underline focus:outline-none focus:ring-1 focus:ring-purple-300"
             >
               {isSignup ? 'Login' : 'Sign Up'}
             </button>
           </div>
         </form>
 
-        {/* Divider */}
-        <div className="my-8">
+        <div className="my-8" aria-hidden="true">
           <div className="relative">
             <div className="absolute inset-0 flex items-center">
               <div className="w-full px-2 border-t border-white/20"></div>
@@ -178,17 +192,16 @@ export function LoginForm({ closeModal }: ModalProps) {
           </div>
         </div>
 
-        {/* Google Login button */}
         <button
           type="button"
-          className="w-full px-2 h-14 bg-transparent border-white/20 text-white hover:bg-white/5 rounded-xl"
+          aria-label="Continue with Google"
+          className="w-full px-2 h-14 bg-transparent border border-white/20 text-white hover:bg-white/5 rounded-xl focus:outline-none focus:ring-2 focus:ring-white/60"
           onClick={() => {
-            // Add Google OAuth logic here
             console.log('Google login clicked');
           }}
         >
           <div className="flex items-center justify-center space-x-3">
-            <svg className="w-5 h-5" viewBox="0 0 24 24">
+            <svg className="w-5 h-5" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
               <path
                 fill="#4285F4"
                 d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z"

--- a/frontend/src/components/SessionResultCard.tsx
+++ b/frontend/src/components/SessionResultCard.tsx
@@ -1,0 +1,163 @@
+"use client";
+
+export type SessionKind = "daily" | "practice" | "interrupted";
+
+export interface SessionResultData {
+  kind: SessionKind;
+  /** Word the player was trying to guess */
+  word: string;
+  /** Whether the player won */
+  won: boolean;
+  /** Number of guesses used (1–6) */
+  guessCount: number;
+  /** Current win streak from on-chain projection */
+  streak: number;
+  /** On-chain session ID (used for share URL) */
+  sessionId?: string;
+  /** Confirmed tx hash, if available */
+  txHash?: string;
+  /** ISO date string for daily sessions */
+  date?: string;
+}
+
+interface SessionResultCardProps {
+  result: SessionResultData;
+  /** Called when the user taps "Share". Receives the share text. */
+  onShare?: (text: string) => void;
+}
+
+const KIND_LABEL: Record<SessionKind, string> = {
+  daily: "Daily",
+  practice: "Practice",
+  interrupted: "Incomplete",
+};
+
+function buildShareText(result: SessionResultData): string {
+  const emoji = result.won ? "🟩" : "🟥";
+  const kindLabel = KIND_LABEL[result.kind];
+  const dateStr = result.date ? ` · ${result.date}` : "";
+  const guessLine = result.won
+    ? `Solved in ${result.guessCount}/6`
+    : "Did not solve";
+  return `DeWordle ${kindLabel}${dateStr}\n${guessLine} — Streak: ${result.streak}\n${emoji.repeat(result.guessCount)}`;
+}
+
+function OutcomeBadge({ won, kind }: { won: boolean; kind: SessionKind }) {
+  if (kind === "interrupted") {
+    return (
+      <span className="rounded-full bg-yellow-400/20 px-3 py-1 text-xs font-semibold text-yellow-300">
+        Incomplete
+      </span>
+    );
+  }
+  return won ? (
+    <span className="rounded-full bg-green-500/20 px-3 py-1 text-xs font-semibold text-green-400">
+      Solved ✓
+    </span>
+  ) : (
+    <span className="rounded-full bg-red-500/20 px-3 py-1 text-xs font-semibold text-red-400">
+      Better luck next time
+    </span>
+  );
+}
+
+/**
+ * Shareable result card generated from Soroban projection data.
+ * Handles daily, practice, and interrupted session layouts without
+ * duplicating markup — layout differences are purely conditional text/badges.
+ */
+export function SessionResultCard({ result, onShare }: SessionResultCardProps) {
+  const { kind, word, won, guessCount, streak, txHash, date } = result;
+  const isInterrupted = kind === "interrupted";
+
+  const handleShare = async () => {
+    const text = buildShareText(result);
+    if (onShare) {
+      onShare(text);
+      return;
+    }
+    if (typeof navigator !== "undefined" && navigator.share) {
+      await navigator.share({ text });
+    } else if (typeof navigator !== "undefined" && navigator.clipboard) {
+      await navigator.clipboard.writeText(text);
+    }
+  };
+
+  return (
+    <article
+      aria-label={`${KIND_LABEL[kind]} session result`}
+      className="flex flex-col gap-5 rounded-2xl border border-white/10 bg-gradient-to-b from-[#1a0b3d] to-[#2d1b69] p-6 shadow-xl text-white max-w-sm w-full"
+    >
+      {/* Header row */}
+      <div className="flex items-center justify-between">
+        <div className="flex flex-col gap-0.5">
+          <span className="text-xs font-medium uppercase tracking-widest text-purple-300">
+            {KIND_LABEL[kind]}
+            {date && <span className="ml-2 text-gray-400 normal-case tracking-normal">{date}</span>}
+          </span>
+          <span className="text-2xl font-bold tracking-widest">
+            {isInterrupted ? "———" : word.toUpperCase()}
+          </span>
+        </div>
+        <OutcomeBadge won={won} kind={kind} />
+      </div>
+
+      {/* Stats row */}
+      <div className="grid grid-cols-2 gap-3">
+        <div className="flex flex-col items-center rounded-xl bg-white/5 py-4">
+          <span className="text-3xl font-bold">
+            {isInterrupted ? "—" : won ? `${guessCount}/6` : "X/6"}
+          </span>
+          <span className="text-xs text-gray-400 mt-1">Guesses</span>
+        </div>
+        <div className="flex flex-col items-center rounded-xl bg-white/5 py-4">
+          <span className="text-3xl font-bold">{streak}</span>
+          <span className="text-xs text-gray-400 mt-1">Streak</span>
+        </div>
+      </div>
+
+      {/* Guess squares */}
+      {!isInterrupted && (
+        <div
+          aria-label={`${guessCount} guess${guessCount !== 1 ? "es" : ""} used`}
+          className="flex gap-1.5 justify-center"
+        >
+          {Array.from({ length: 6 }).map((_, i) => (
+            <div
+              key={i}
+              className={`h-4 w-4 rounded-sm ${
+                i < guessCount
+                  ? won
+                    ? "bg-green-500"
+                    : i < guessCount - 1
+                      ? "bg-yellow-400"
+                      : "bg-red-500"
+                  : "bg-white/10"
+              }`}
+            />
+          ))}
+        </div>
+      )}
+
+      {/* On-chain tx hash */}
+      {txHash && (
+        <p className="text-center text-xs text-gray-500 truncate">
+          On-chain:{" "}
+          <span className="font-mono" title={txHash}>
+            {txHash.slice(0, 10)}…{txHash.slice(-6)}
+          </span>
+        </p>
+      )}
+
+      {/* Share button */}
+      <button
+        type="button"
+        onClick={handleShare}
+        className="w-full rounded-xl py-3 text-sm font-semibold bg-purple-600 hover:bg-purple-500 transition-colors focus:outline-none focus:ring-2 focus:ring-purple-400"
+        aria-label="Share your result"
+      >
+        Share Result
+      </button>
+    </article>
+  );
+}

--- a/frontend/src/components/TxStatusTimeline.tsx
+++ b/frontend/src/components/TxStatusTimeline.tsx
@@ -34,17 +34,27 @@ interface TxStatusTimelineProps {
 export function TxStatusTimeline({ status }: TxStatusTimelineProps) {
   const isError = status.state === "error";
   const activeIndex = isError ? -1 : STEPS.indexOf(status.state);
+  const statusLabel = isError
+    ? `Transaction failed: ${status.error ?? "Unknown error"}`
+    : `Transaction status: ${STEP_LABELS[status.state]}`;
 
   return (
-    <div aria-label="Transaction status" className="w-full">
-      {/* Step indicators */}
-      <ol className="flex items-center justify-between gap-1">
+    <div
+      aria-label="Transaction status"
+      aria-live="polite"
+      aria-atomic="true"
+      className="w-full"
+    >
+      {/* Visually hidden live region for screen readers */}
+      <span className="sr-only">{statusLabel}</span>
+
+      <ol className="flex items-center justify-between gap-1" aria-hidden="true">
         {STEPS.map((step, i) => {
           const isDone = !isError && i < activeIndex;
           const isActive = !isError && i === activeIndex;
 
           return (
-            <li key={step} className="flex flex-1 flex-col items-center gap-1">
+            <li key={step} className="relative flex flex-1 flex-col items-center gap-1">
               {/* Connector line */}
               {i > 0 && (
                 <div
@@ -83,7 +93,6 @@ export function TxStatusTimeline({ status }: TxStatusTimelineProps) {
         })}
       </ol>
 
-      {/* Error state */}
       {isError && (
         <p
           role="alert"
@@ -94,7 +103,6 @@ export function TxStatusTimeline({ status }: TxStatusTimelineProps) {
         </p>
       )}
 
-      {/* Success: tx hash */}
       {status.state === "success" && status.txHash && (
         <p className="mt-2 truncate text-center text-xs text-gray-500">
           Tx:{" "}

--- a/frontend/src/components/header.tsx
+++ b/frontend/src/components/header.tsx
@@ -1,5 +1,5 @@
 'use client';
-import { useMemo } from 'react';
+import { useMemo, useState } from 'react';
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 import { createAvatar } from '@dicebear/core';
@@ -25,6 +25,7 @@ const navItems = [
 export default function Header() {
   const pathname = usePathname();
   const { isAuthenticated, user } = useAuth();
+  const [menuOpen, setMenuOpen] = useState(false);
   const isActive = (href: string) => pathname === href;
   const avatar = useMemo(() => {
     return createAvatar(adventurer, {
@@ -35,22 +36,40 @@ export default function Header() {
 
   return (
     <div>
-      <nav className="flex items-center rounded-[40px]  fixed z-20 top-5 left-1/2 transform -translate-x-1/2 w-full justify-between lg:justify-center max-w-[90%] lg:max-w-[1088px] mx-auto  gap-4 lg:gap-15 p-5 md:px-4.5 md:py-4 bg-dark-100/30 md:rounded-2xl backdrop-blur-[5px]">
+      <nav
+        aria-label="Main navigation"
+        className="flex items-center rounded-[40px]  fixed z-20 top-5 left-1/2 transform -translate-x-1/2 w-full justify-between lg:justify-center max-w-[90%] lg:max-w-[1088px] mx-auto  gap-4 lg:gap-15 p-5 md:px-4.5 md:py-4 bg-dark-100/30 md:rounded-2xl backdrop-blur-[5px]"
+      >
         <div className="flex items-center gap-1 md:gap-2">
           <div className="relative w-14 md:w-23 h-4 md:h-6">
-            <Image alt="lead studio" src="/logo.svg" width={91} height={24} />
+            <Image alt="DeWordle Studio" src="/logo.svg" width={91} height={24} />
           </div>
           <div className="font-clash font-normal text-white text-base md:text-2xl tracking-widest">
             Studio
           </div>
         </div>
 
-        <MenuIcon className="block md:hidden" />
-        <div className="hidden lg:flex items-center justify-center p-2.5 w-[35rem]">
+        <button
+          type="button"
+          aria-label="Open menu"
+          aria-expanded={menuOpen}
+          aria-controls="mobile-menu"
+          onClick={() => setMenuOpen((prev) => !prev)}
+          className="block md:hidden"
+        >
+          <MenuIcon aria-hidden="true" />
+        </button>
+
+        <ul
+          id="mobile-menu"
+          role="list"
+          className="hidden lg:flex items-center justify-center p-2.5 w-[35rem]"
+        >
           {navItems.map((item, index) => (
-            <div key={item.label} className="flex items-center">
+            <li key={item.label} className="flex items-center">
               <Link
                 href={item.href}
+                aria-current={isActive(item.href) ? 'page' : undefined}
                 className={`font-jakarta font-semibold text-lg tracking-wide whitespace-nowrap ${
                   isActive(item.href) ? 'text-white' : 'text-gray-400'
                 }`}
@@ -58,22 +77,22 @@ export default function Header() {
                 {item.label}
               </Link>
               {index < navItems.length - 1 && (
-                <div className="h-6 w-0.5 mx-8 bg-[#4b5fff]" />
+                <div aria-hidden="true" className="h-6 w-0.5 mx-8 bg-[#4b5fff]" />
               )}
-            </div>
+            </li>
           ))}
-        </div>
+        </ul>
 
         {!isAuthenticated && (
           <Popover>
-            <PopoverTrigger>
-              <div className="hidden md:flex">
-                <div
-                  className="px-6 py-4 rounded-lg border-[0.5px] border-white bg-transparent hover:bg-white/10 text-white font-jakarta text-lg tracking-wide font-medium leading-6"
-                >
-                  Login / Sign up
-                </div>
-              </div>
+            <PopoverTrigger asChild>
+              <button
+                type="button"
+                aria-label="Open login or sign up modal"
+                className="hidden md:flex px-6 py-4 rounded-lg border-[0.5px] border-white bg-transparent hover:bg-white/10 text-white font-jakarta text-lg tracking-wide font-medium leading-6 focus:outline-none focus:ring-2 focus:ring-white/60"
+              >
+                Login / Sign up
+              </button>
             </PopoverTrigger>
             <PopoverContent>
               <LoginForm closeModal={() => undefined} />
@@ -85,14 +104,18 @@ export default function Header() {
             <div className="border p-1 rounded-full">
               <Image
                 src={avatar}
-                alt="User Avatar"
+                alt={`${user?.username ?? 'User'} avatar`}
                 width={30}
                 height={30}
                 className="rounded-full"
               />
             </div>
-            <button className=" cursor-pointer">
-              <Bell />
+            <button
+              type="button"
+              aria-label="View notifications"
+              className="cursor-pointer focus:outline-none focus:ring-2 focus:ring-white/60 rounded-full p-1"
+            >
+              <Bell aria-hidden="true" />
             </button>
           </div>
         )}

--- a/frontend/src/components/skeletons/AchievementsSkeleton.tsx
+++ b/frontend/src/components/skeletons/AchievementsSkeleton.tsx
@@ -1,0 +1,37 @@
+import { Skeleton } from "@/components/ui/skeleton";
+
+export function AchievementsSkeleton() {
+  return (
+    <div
+      role="status"
+      aria-label="Loading achievements"
+      className="flex flex-col gap-6 w-full max-w-2xl mx-auto p-4"
+    >
+      {/* Section heading */}
+      <Skeleton className="h-7 w-44 rounded" />
+
+      {/* Achievement rows */}
+      {Array.from({ length: 5 }).map((_, i) => (
+        <div
+          key={i}
+          className="flex items-center gap-4 rounded-xl border border-white/10 p-4"
+        >
+          {/* Badge icon */}
+          <Skeleton className="h-12 w-12 rounded-full shrink-0" />
+
+          <div className="flex flex-col gap-2 flex-1">
+            <Skeleton className="h-4 w-40 rounded" />
+            <Skeleton className="h-3 w-56 rounded" />
+            {/* Progress bar */}
+            <Skeleton className="h-2 w-full rounded-full" />
+          </div>
+
+          {/* Points badge */}
+          <Skeleton className="h-8 w-16 rounded-full shrink-0" />
+        </div>
+      ))}
+
+      <span className="sr-only">Loading achievements…</span>
+    </div>
+  );
+}

--- a/frontend/src/components/skeletons/GameplaySkeleton.tsx
+++ b/frontend/src/components/skeletons/GameplaySkeleton.tsx
@@ -1,0 +1,33 @@
+import { Skeleton } from "@/components/ui/skeleton";
+
+export function GameplaySkeleton() {
+  return (
+    <div
+      role="status"
+      aria-label="Loading gameplay"
+      className="flex flex-col items-center gap-6 w-full max-w-lg mx-auto p-4"
+    >
+      {/* Word row placeholders */}
+      {Array.from({ length: 6 }).map((_, rowIndex) => (
+        <div key={rowIndex} className="flex gap-2">
+          {Array.from({ length: 5 }).map((_, colIndex) => (
+            <Skeleton key={colIndex} className="h-14 w-14 rounded-md" />
+          ))}
+        </div>
+      ))}
+
+      {/* Keyboard placeholder */}
+      <div className="flex flex-col gap-2 w-full max-w-sm mt-4">
+        {[10, 9, 7].map((keys, rowIndex) => (
+          <div key={rowIndex} className="flex justify-center gap-1.5">
+            {Array.from({ length: keys }).map((_, i) => (
+              <Skeleton key={i} className="h-10 flex-1 max-w-[2.5rem] rounded" />
+            ))}
+          </div>
+        ))}
+      </div>
+
+      <span className="sr-only">Loading gameplay board…</span>
+    </div>
+  );
+}

--- a/frontend/src/components/skeletons/ProfileSkeleton.tsx
+++ b/frontend/src/components/skeletons/ProfileSkeleton.tsx
@@ -1,0 +1,46 @@
+import { Skeleton } from "@/components/ui/skeleton";
+
+export function ProfileSkeleton() {
+  return (
+    <div
+      role="status"
+      aria-label="Loading profile"
+      className="flex flex-col gap-6 w-full max-w-2xl mx-auto p-4"
+    >
+      {/* Avatar + name */}
+      <div className="flex items-center gap-4">
+        <Skeleton className="h-20 w-20 rounded-full" />
+        <div className="flex flex-col gap-2 flex-1">
+          <Skeleton className="h-6 w-40 rounded" />
+          <Skeleton className="h-4 w-56 rounded" />
+        </div>
+      </div>
+
+      {/* Stats row */}
+      <div className="grid grid-cols-3 gap-4">
+        {Array.from({ length: 3 }).map((_, i) => (
+          <div key={i} className="flex flex-col gap-2 rounded-xl border border-white/10 p-4">
+            <Skeleton className="h-8 w-12 rounded" />
+            <Skeleton className="h-4 w-20 rounded" />
+          </div>
+        ))}
+      </div>
+
+      {/* Recent games list */}
+      <div className="flex flex-col gap-3">
+        {Array.from({ length: 4 }).map((_, i) => (
+          <div key={i} className="flex items-center gap-3 rounded-xl border border-white/10 p-3">
+            <Skeleton className="h-10 w-10 rounded-md shrink-0" />
+            <div className="flex flex-col gap-1.5 flex-1">
+              <Skeleton className="h-4 w-32 rounded" />
+              <Skeleton className="h-3 w-20 rounded" />
+            </div>
+            <Skeleton className="h-6 w-14 rounded-full" />
+          </div>
+        ))}
+      </div>
+
+      <span className="sr-only">Loading profile…</span>
+    </div>
+  );
+}

--- a/frontend/src/components/skeletons/RewardsSkeleton.tsx
+++ b/frontend/src/components/skeletons/RewardsSkeleton.tsx
@@ -1,0 +1,33 @@
+import { Skeleton } from "@/components/ui/skeleton";
+
+export function RewardsSkeleton() {
+  return (
+    <div
+      role="status"
+      aria-label="Loading rewards"
+      className="flex flex-col gap-6 w-full max-w-2xl mx-auto p-4"
+    >
+      {/* Section heading */}
+      <Skeleton className="h-7 w-36 rounded" />
+
+      {/* Reward cards grid */}
+      <div className="grid grid-cols-2 gap-4 sm:grid-cols-3">
+        {Array.from({ length: 6 }).map((_, i) => (
+          <div
+            key={i}
+            className="flex flex-col items-center gap-3 rounded-xl border border-white/10 p-5"
+          >
+            <Skeleton className="h-14 w-14 rounded-full" />
+            <Skeleton className="h-4 w-24 rounded" />
+            <Skeleton className="h-3 w-16 rounded" />
+          </div>
+        ))}
+      </div>
+
+      {/* Claim button placeholder */}
+      <Skeleton className="h-12 w-40 rounded-xl self-center" />
+
+      <span className="sr-only">Loading rewards…</span>
+    </div>
+  );
+}

--- a/frontend/src/components/skeletons/index.ts
+++ b/frontend/src/components/skeletons/index.ts
@@ -1,0 +1,4 @@
+export { GameplaySkeleton } from "./GameplaySkeleton";
+export { ProfileSkeleton } from "./ProfileSkeleton";
+export { RewardsSkeleton } from "./RewardsSkeleton";
+export { AchievementsSkeleton } from "./AchievementsSkeleton";

--- a/frontend/src/components/ui/skeleton.tsx
+++ b/frontend/src/components/ui/skeleton.tsx
@@ -1,0 +1,14 @@
+import { cn } from "@/lib/utils";
+
+export function Skeleton({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) {
+  return (
+    <div
+      aria-hidden="true"
+      className={cn("animate-pulse rounded-md bg-white/10", className)}
+      {...props}
+    />
+  );
+}

--- a/frontend/src/hooks/useGameplayTx.ts
+++ b/frontend/src/hooks/useGameplayTx.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useStellarWallet } from "@/hooks/useStellarWallet";
 import { nextLifecycle, reconcileGameplayState, type GameplayTxSnapshot } from "@/lib/stellar/gameplay-flow";
 
@@ -16,6 +16,18 @@ export function useGameplayTx() {
   const [snapshot, setSnapshot] = useState<GameplayTxSnapshot>({});
   // In-flight lock: prevents duplicate submissions
   const inFlightRef = useRef(false);
+
+  // Reset all optimistic state whenever the connected wallet account changes.
+  // Leaving stale session snapshots mounted after an account switch would let
+  // the new user see (and potentially interact with) the previous account's
+  // in-flight or confirmed session data.
+  useEffect(() => {
+    return wallet.onAccountSwitch(() => {
+      inFlightRef.current = false;
+      setSnapshot({});
+      wallet.setTxStatus({ id: "", state: "idle" });
+    });
+  }, [wallet]);
 
   const networkMismatch = useMemo(() => {
     const configured = process.env.NEXT_PUBLIC_STELLAR_NETWORK;

--- a/frontend/src/hooks/useStellarWallet.ts
+++ b/frontend/src/hooks/useStellarWallet.ts
@@ -14,6 +14,7 @@ export function useStellarWallet() {
     setTxStatus,
     signTransaction,
     submitTransaction,
+    onAccountSwitch,
   } = useWalletContext();
 
   return {
@@ -27,5 +28,6 @@ export function useStellarWallet() {
     setTxStatus,
     signTransaction,
     submitTransaction,
+    onAccountSwitch,
   };
 }

--- a/frontend/src/providers/stellar-wallet-provider.tsx
+++ b/frontend/src/providers/stellar-wallet-provider.tsx
@@ -4,7 +4,9 @@ import {
   createContext,
   useCallback,
   useContext,
+  useEffect,
   useMemo,
+  useRef,
   useState,
   type ReactNode,
 } from "react";
@@ -27,6 +29,8 @@ type WalletState = {
   setTxStatus: (status: TxLifecycleStatus) => void;
   signTransaction: (transactionXdr: string) => Promise<string>;
   submitTransaction: (signedTxXdr: string) => Promise<{ hash: string }>;
+  /** Registers a callback that fires whenever the active wallet account changes. */
+  onAccountSwitch: (cb: (newAddress: string) => void) => () => void;
 };
 
 type WalletKitLike = {
@@ -52,6 +56,48 @@ export function StellarWalletProvider({ children }: { children: ReactNode }) {
   const [address, setAddress] = useState<string | undefined>(undefined);
   const [network, setNetwork] = useState<StellarNetwork>(getDefaultNetwork());
   const [status, setStatus] = useState<TxLifecycleStatus>(defaultStatus);
+
+  // Set of callbacks notified when the active wallet account changes.
+  const switchListenersRef = useRef<Set<(addr: string) => void>>(new Set());
+
+  const onAccountSwitch = useCallback((cb: (newAddress: string) => void) => {
+    switchListenersRef.current.add(cb);
+    return () => switchListenersRef.current.delete(cb);
+  }, []);
+
+  // Poll Freighter for address changes on tab focus / visibility change.
+  // This is the only reliable way to detect Freighter account switches since
+  // the extension doesn't emit DOM events when the user switches accounts.
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+
+    const checkForAccountSwitch = async () => {
+      if (!connected) return;
+      const freighter = window.freighterApi;
+      if (!freighter?.getAddress) return;
+
+      try {
+        const response = await freighter.getAddress();
+        if (!response || response.error || !response.address) return;
+        const nextAddress = response.address;
+
+        if (nextAddress !== address) {
+          setAddress(nextAddress);
+          setStatus(defaultStatus);
+          switchListenersRef.current.forEach((cb) => cb(nextAddress));
+        }
+      } catch {
+        // Silently ignore polling errors; they resolve on the next successful poll.
+      }
+    };
+
+    window.addEventListener("focus", checkForAccountSwitch);
+    document.addEventListener("visibilitychange", checkForAccountSwitch);
+    return () => {
+      window.removeEventListener("focus", checkForAccountSwitch);
+      document.removeEventListener("visibilitychange", checkForAccountSwitch);
+    };
+  }, [connected, address]);
 
   const connect = useCallback(async () => {
     if (typeof window === "undefined") {
@@ -158,6 +204,7 @@ export function StellarWalletProvider({ children }: { children: ReactNode }) {
       setTxStatus,
       signTransaction,
       submitTransaction,
+      onAccountSwitch,
     }),
     [
       connected,
@@ -170,6 +217,7 @@ export function StellarWalletProvider({ children }: { children: ReactNode }) {
       setTxStatus,
       signTransaction,
       submitTransaction,
+      onAccountSwitch,
     ],
   );
 


### PR DESCRIPTION
## Summary

Closes #747
Closes #748 
Closes #749 
Closes #751

This PR addresses four Stellar Wave issues across the frontend in a single cohesive change set.

---

### FE-209 · Standardize loading skeletons for Soroban-backed views (#747)

- Added `src/components/ui/skeleton.tsx` — a reusable base `<Skeleton>` component (animated pulse, `aria-hidden`) built on `cn()` / Tailwind.
- Added four view-specific skeletons under `src/components/skeletons/`, each with a `role="status"` wrapper and `sr-only` text for screen readers:
  - `GameplaySkeleton` — 6-row word grid + 3-row keyboard layout
  - `ProfileSkeleton` — avatar, stats grid, recent games list
  - `RewardsSkeleton` — reward card grid + claim button
  - `AchievementsSkeleton` — achievement rows with progress bars
- All four are re-exported from `src/components/skeletons/index.ts`.

---

### FE-210 · Accessibility pass on wallet and gameplay flows (#748)

**`header.tsx`**
- `<nav>` gains `aria-label="Main navigation"`.
- Active nav links get `aria-current="page"`.
- Mobile menu icon is wrapped in a `<button>` with `aria-label="Open menu"` and `aria-expanded`.
- Logo `alt` text updated to `"DeWordle Studio"`.
- Avatar `alt` reflects the actual username.
- Notification button gets `aria-label="View notifications"` + focus ring.
- Login trigger is a real `<button>` with `aria-label` + focus ring.
- Nav items are rendered in a `<ul>` / `<li>` list.

**`LoginModal.tsx`**
- Each field has a matching `<label htmlFor>` (visually hidden via `sr-only`).
- Inputs have `aria-required="true"` and correct `autocomplete` attributes.
- Error container gets `role="alert"` + `aria-live="assertive"`.
- Outer div gets `role="dialog"` + `aria-modal="true"` + `aria-labelledby` pointing to the heading.
- Close button gets `aria-label="Close dialog"` + focus ring.
- Submit button gets `aria-disabled` mirroring `disabled`.

**`TxStatusTimeline.tsx`**
- Outer wrapper gets `aria-live="polite"` + `aria-atomic="true"`.
- A `sr-only` `<span>` announces the human-readable status string to screen readers on every state change.
- The visual `<ol>` is marked `aria-hidden="true"` to avoid double-announcing.
- Fixed missing `relative` class on `<li>` that caused connector lines to escape their containing element.

---

### FE-211 · Shareable session result cards from projection data (#749)

- Added `src/components/SessionResultCard.tsx`.
- Accepts `SessionResultData` — `kind` (daily / practice / interrupted), `word`, `won`, `guessCount`, `streak`, optional `txHash` and `date`.
- Three session kinds share one layout; variant differences are conditional text and badges — no markup duplication.
- Share flow: calls `navigator.share` if available, falls back to `navigator.clipboard`, or invokes a custom `onShare` prop.
- Includes on-chain tx hash display (truncated, full value in `title`).
- Fully accessible: `<article>` with `aria-label`, `aria-label` on the guess-square container, accessible share button.

---

### FE-213 · Detect wallet account switches and reset unsafe cached state (#751)

**`stellar-wallet-provider.tsx`**
- Added `onAccountSwitch(cb)` to `WalletState` — registers a listener that fires with the new address whenever the active Freighter account changes.
- Added a `useEffect` that attaches `focus` and `visibilitychange` listeners and polls `freighter.getAddress()` on each event. When the returned address differs from current state, it: updates `address`, resets `status` to idle, and notifies all registered listeners.

**`useStellarWallet.ts`**
- Exposes `onAccountSwitch` from context.

**`useGameplayTx.ts`**
- Registers an `onAccountSwitch` callback via `useEffect`. On switch: clears the gameplay snapshot, releases the in-flight lock, and resets tx status to idle — preventing the new account from seeing stale session data.

---

## Validation

```
✔ next lint       — no warnings or errors
✔ tsc --noEmit    — no type errors
✔ vitest run      — 21/21 tests passed
✔ next build      — compiled successfully, all pages static
```

## Test plan

- [ ] Switch Freighter accounts while a game session is in-flight → snapshot resets, no stale UI shown for new account
- [ ] Open gameplay, profile, rewards, and achievements views with Soroban data loading → skeleton placeholders render with correct shape
- [ ] Navigate with keyboard through header, login modal, and tx timeline → focus order is correct, screen reader announces status changes
- [ ] Complete a daily, practice, and abandoned session → result card renders the correct layout for each; Share button copies/shares result text
- [ ] Run `pnpm lint && pnpm typecheck && pnpm test && pnpm build` locally