### PR TITLE
feat(backend): env validation, registry snapshots, projection versioning, reward API

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -1,6 +1,7 @@
 import { Module } from '@nestjs/common';
 import { ConfigModule, ConfigService } from '@nestjs/config';
 import { TypeOrmModule } from '@nestjs/typeorm';
+import { validateEnv } from './config/env.validation';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
 import { TestEntity } from './entities/test.entity';
@@ -20,6 +21,7 @@ import { IndexerModule } from './indexer/indexer.module';
     ConfigModule.forRoot({
       isGlobal: true,
       envFilePath: ['.env', '.env.development'],
+      validate: validateEnv,
     }),
     ScheduleModule.forRoot(),
     EventEmitterModule.forRoot(),

--- a/backend/src/common/dto/reward-summary.dto.ts
+++ b/backend/src/common/dto/reward-summary.dto.ts
@@ -1,0 +1,50 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+
+/**
+ * Represents the state of a player's on-chain reward balance.
+ * 'unavailable' signals that projection data is not yet indexed for this player.
+ */
+export type RewardFieldState = 'available' | 'pending' | 'unavailable';
+
+export class RewardSummaryDto {
+  @ApiProperty({
+    description: 'Total reward tokens accrued by the player across all sessions',
+    example: 1500,
+  })
+  accrued: number;
+
+  @ApiProperty({
+    description: 'Total reward tokens already claimed by the player',
+    example: 500,
+  })
+  claimed: number;
+
+  @ApiProperty({
+    description:
+      'Tokens accrued but not yet claimed (accrued − claimed). ' +
+      'May lag on-chain state by one indexer poll cycle.',
+    example: 1000,
+  })
+  pendingClaim: number;
+
+  @ApiProperty({
+    description: 'Number of finalized sessions that contributed to accrued rewards',
+    example: 12,
+  })
+  sessionCount: number;
+
+  @ApiProperty({
+    description:
+      'Data availability state. "unavailable" means no projection data has ' +
+      'been indexed for this player yet.',
+    enum: ['available', 'pending', 'unavailable'],
+    example: 'available',
+  })
+  state: RewardFieldState;
+
+  @ApiPropertyOptional({
+    description: 'ISO timestamp of the most recently indexed session for this player',
+    example: '2026-06-26T07:00:00.000Z',
+  })
+  lastUpdatedAt?: string;
+}

--- a/backend/src/config/env.validation.spec.ts
+++ b/backend/src/config/env.validation.spec.ts
@@ -1,0 +1,54 @@
+import { validateEnv } from './env.validation';
+
+const VALID_BASE: Record<string, unknown> = {
+  DB_HOST: 'localhost',
+  DB_USERNAME: 'postgres',
+  DB_PASSWORD: 'secret',
+  DB_NAME: 'dewordle',
+  JWT_SECRET: 'supersecret',
+  SOROBAN_RPC_URL: 'https://soroban-testnet.stellar.org',
+  SOROBAN_CORE_GAME_CONTRACT_ID: 'CAABC123',
+};
+
+describe('validateEnv', () => {
+  it('passes with all required variables present', () => {
+    expect(() => validateEnv(VALID_BASE)).not.toThrow();
+  });
+
+  it('applies defaults for optional variables', () => {
+    const result = validateEnv(VALID_BASE);
+    expect(result.PORT).toBe(3000);
+    expect(result.SOROBAN_NETWORK).toBe('testnet');
+    expect(result.INDEXER_MAX_PAYLOAD_BYTES).toBe(8192);
+  });
+
+  it('throws when DB_HOST is missing', () => {
+    const { DB_HOST: _removed, ...rest } = VALID_BASE;
+    expect(() => validateEnv(rest)).toThrow('Environment validation failed');
+  });
+
+  it('throws when JWT_SECRET is missing', () => {
+    const { JWT_SECRET: _removed, ...rest } = VALID_BASE;
+    expect(() => validateEnv(rest)).toThrow('Environment validation failed');
+  });
+
+  it('throws when SOROBAN_RPC_URL is missing', () => {
+    const { SOROBAN_RPC_URL: _removed, ...rest } = VALID_BASE;
+    expect(() => validateEnv(rest)).toThrow('Environment validation failed');
+  });
+
+  it('throws when SOROBAN_CORE_GAME_CONTRACT_ID is missing', () => {
+    const { SOROBAN_CORE_GAME_CONTRACT_ID: _removed, ...rest } = VALID_BASE;
+    expect(() => validateEnv(rest)).toThrow('Environment validation failed');
+  });
+
+  it('throws when SOROBAN_NETWORK is an invalid value', () => {
+    expect(() =>
+      validateEnv({ ...VALID_BASE, SOROBAN_NETWORK: 'devnet' }),
+    ).toThrow('Environment validation failed');
+  });
+
+  it('collects all missing-field errors in one throw', () => {
+    expect(() => validateEnv({})).toThrow('Environment validation failed');
+  });
+});

--- a/backend/src/config/env.validation.ts
+++ b/backend/src/config/env.validation.ts
@@ -1,0 +1,110 @@
+import {
+  IsEnum,
+  IsInt,
+  IsNotEmpty,
+  IsOptional,
+  IsString,
+  IsUrl,
+  Max,
+  Min,
+  validateSync,
+} from 'class-validator';
+import { plainToInstance } from 'class-transformer';
+
+export enum NodeEnv {
+  Development = 'development',
+  Production = 'production',
+  Test = 'test',
+}
+
+export enum StellarNetwork {
+  Testnet = 'testnet',
+  Mainnet = 'mainnet',
+}
+
+class EnvironmentVariables {
+  // ── Server ──────────────────────────────────────────────────────────────────
+  @IsOptional()
+  @IsEnum(NodeEnv)
+  NODE_ENV: NodeEnv = NodeEnv.Development;
+
+  @IsOptional()
+  @IsInt()
+  @Min(1)
+  @Max(65535)
+  PORT: number = 3000;
+
+  // ── Database ─────────────────────────────────────────────────────────────────
+  @IsNotEmpty()
+  @IsString()
+  DB_HOST: string;
+
+  @IsOptional()
+  @IsInt()
+  @Min(1)
+  @Max(65535)
+  DB_PORT: number = 5432;
+
+  @IsNotEmpty()
+  @IsString()
+  DB_USERNAME: string;
+
+  @IsNotEmpty()
+  @IsString()
+  DB_PASSWORD: string;
+
+  @IsNotEmpty()
+  @IsString()
+  DB_NAME: string;
+
+  // ── Auth ─────────────────────────────────────────────────────────────────────
+  @IsNotEmpty()
+  @IsString()
+  JWT_SECRET: string;
+
+  @IsOptional()
+  @IsUrl()
+  FRONTEND_URL: string = 'http://localhost:3000';
+
+  // ── Soroban / Indexer ─────────────────────────────────────────────────────
+  @IsNotEmpty()
+  @IsUrl()
+  SOROBAN_RPC_URL: string;
+
+  @IsNotEmpty()
+  @IsString()
+  SOROBAN_CORE_GAME_CONTRACT_ID: string;
+
+  @IsOptional()
+  @IsEnum(StellarNetwork)
+  SOROBAN_NETWORK: StellarNetwork = StellarNetwork.Testnet;
+
+  @IsOptional()
+  @IsInt()
+  @Min(1)
+  INDEXER_MAX_PAYLOAD_BYTES: number = 8192;
+}
+
+/**
+ * Validates all required environment variables at application startup.
+ * Throws a descriptive error immediately if any required var is missing or
+ * malformed — prevents partial-startup failures deep inside request handlers.
+ */
+export function validateEnv(config: Record<string, unknown>) {
+  const validated = plainToInstance(EnvironmentVariables, config, {
+    enableImplicitConversion: true,
+  });
+
+  const errors = validateSync(validated, { skipMissingProperties: false });
+
+  if (errors.length > 0) {
+    const messages = errors
+      .flatMap((e) => Object.values(e.constraints ?? {}))
+      .join('\n  ');
+    throw new Error(
+      `Environment validation failed at startup:\n  ${messages}\n\nCheck your .env file or deployment config.`,
+    );
+  }
+
+  return validated;
+}

--- a/backend/src/indexer/entities/registry-snapshot.entity.ts
+++ b/backend/src/indexer/entities/registry-snapshot.entity.ts
@@ -1,0 +1,44 @@
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  Index,
+  PrimaryGeneratedColumn,
+  UpdateDateColumn,
+} from 'typeorm';
+
+/**
+ * Persists a point-in-time snapshot of the Soroban contract registry for a
+ * given network. Backend services that need the latest known registry state
+ * read from this table instead of making live RPC calls, making them resilient
+ * to transient network outages.
+ *
+ * One row per (network, contractId) — upserted on every successful registry
+ * fetch so the table always reflects the most recently observed state.
+ */
+@Entity('registry_snapshots')
+@Index(['network', 'contractId'], { unique: true })
+export class RegistrySnapshotEntity {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column()
+  network: string;
+
+  @Column()
+  contractId: string;
+
+  /** Raw registry payload as returned by the Soroban SDK. */
+  @Column({ type: 'jsonb' })
+  registry: Record<string, unknown>;
+
+  /** Ledger sequence number at which this snapshot was captured. */
+  @Column({ default: 0 })
+  capturedAtLedger: number;
+
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @UpdateDateColumn()
+  updatedAt: Date;
+}

--- a/backend/src/indexer/entities/session-projection.entity.ts
+++ b/backend/src/indexer/entities/session-projection.entity.ts
@@ -33,6 +33,14 @@ export class SessionProjectionEntity {
   @Column({ default: false })
   finalized: boolean;
 
+  /**
+   * Schema version of this projection row. Compared against
+   * CURRENT_PROJECTION_VERSION at read time to detect stale rows that need
+   * a migration pass before being served to consumers.
+   */
+  @Column({ default: 1 })
+  schemaVersion: number;
+
   @UpdateDateColumn()
   updatedAt: Date;
 }

--- a/backend/src/indexer/indexer.module.ts
+++ b/backend/src/indexer/indexer.module.ts
@@ -12,6 +12,10 @@ import { ReplayAlertService } from './queue/replay-alert.service';
 import { IngestedEventEntity } from './entities/ingested-event.entity';
 import { SessionProjectionEntity } from './entities/session-projection.entity';
 import { IndexerCursorEntity } from './entities/indexer-cursor.entity';
+import { RegistrySnapshotEntity } from './entities/registry-snapshot.entity';
+import { RegistrySnapshotService } from './registry/registry-snapshot.service';
+import { RewardSummaryService } from './reward-summary.service';
+import { RewardSummaryController } from './reward-summary.controller';
 
 @Module({
   imports: [
@@ -19,9 +23,10 @@ import { IndexerCursorEntity } from './entities/indexer-cursor.entity';
       IngestedEventEntity,
       SessionProjectionEntity,
       IndexerCursorEntity,
+      RegistrySnapshotEntity,
     ]),
   ],
-  controllers: [IndexerController],
+  controllers: [IndexerController, RewardSummaryController],
   providers: [
     IndexerService,
     EventProcessorService,
@@ -31,12 +36,16 @@ import { IndexerCursorEntity } from './entities/indexer-cursor.entity';
     IndexerQueueService,
     ReplayAlertService,
     IndexerWorkerService,
+    RegistrySnapshotService,
+    RewardSummaryService,
   ],
   exports: [
     IndexerService,
     ProjectionService,
     CursorService,
     EventNormalizerService,
+    RegistrySnapshotService,
+    RewardSummaryService,
   ],
 })
 export class IndexerModule {}

--- a/backend/src/indexer/projections/projection-version.ts
+++ b/backend/src/indexer/projections/projection-version.ts
@@ -1,0 +1,65 @@
+/**
+ * Projection schema versioning and migration strategy hooks.
+ *
+ * Increment CURRENT_PROJECTION_VERSION whenever the shape of
+ * SessionProjectionEntity changes in a way that would make existing rows
+ * incompatible with new read paths. Consumers can detect stale rows by
+ * comparing their stored schemaVersion against CURRENT_PROJECTION_VERSION.
+ *
+ * Migration flow:
+ *  1. Bump CURRENT_PROJECTION_VERSION.
+ *  2. Implement a ProjectionMigration that handles the (from → to) transition.
+ *  3. Register it in PROJECTION_MIGRATIONS.
+ *  4. The migration runner picks it up automatically at startup.
+ */
+export const CURRENT_PROJECTION_VERSION = 1;
+
+/**
+ * Describes a single projection schema migration.
+ * Implementations are expected to be idempotent — re-running a migration on
+ * an already-migrated row must be a no-op.
+ */
+export interface ProjectionMigration {
+  /** Version this migration upgrades FROM. */
+  fromVersion: number;
+  /** Version this migration upgrades TO. */
+  toVersion: number;
+  /** Human-readable description surfaced in logs. */
+  description: string;
+  /**
+   * Apply the migration to a single raw projection row.
+   * Returns the mutated row (may be the same object).
+   */
+  migrate(row: Record<string, unknown>): Record<string, unknown>;
+}
+
+/**
+ * Registry of all known projection migrations, ordered ascending by
+ * fromVersion. Add new migrations here; the runner applies them in order.
+ */
+export const PROJECTION_MIGRATIONS: ProjectionMigration[] = [
+  // Example for the next version bump:
+  // {
+  //   fromVersion: 1,
+  //   toVersion: 2,
+  //   description: 'Back-fill rewardAmount from attemptsUsed scoring table',
+  //   migrate(row) {
+  //     row.rewardAmount ??= 0;
+  //     return row;
+  //   },
+  // },
+];
+
+/**
+ * Returns the ordered chain of migrations needed to advance a row from
+ * `fromVersion` to `toVersion`. Returns an empty array if already current.
+ */
+export function getMigrationPath(
+  fromVersion: number,
+  toVersion: number,
+): ProjectionMigration[] {
+  if (fromVersion >= toVersion) return [];
+  return PROJECTION_MIGRATIONS.filter(
+    (m) => m.fromVersion >= fromVersion && m.toVersion <= toVersion,
+  ).sort((a, b) => a.fromVersion - b.fromVersion);
+}

--- a/backend/src/indexer/projections/projection.service.ts
+++ b/backend/src/indexer/projections/projection.service.ts
@@ -4,6 +4,7 @@ import { Repository } from 'typeorm';
 import { SessionProjectionEntity } from '../entities/session-projection.entity';
 import { IngestedEventDto } from '../dto/ingested-event.dto';
 import { IndexerLogContext } from '../indexer.service';
+import { CURRENT_PROJECTION_VERSION } from './projection-version';
 
 @Injectable()
 export class ProjectionService {
@@ -50,6 +51,7 @@ export class ProjectionService {
       status: this.readStringField(event.payload, 'status', 'Finalized'),
       attemptsUsed: Number(event.payload.attemptsUsed ?? 0),
       finalized: true,
+      schemaVersion: CURRENT_PROJECTION_VERSION,
     });
 
     await this.sessionsRepo.save(projection);

--- a/backend/src/indexer/registry/registry-snapshot.service.spec.ts
+++ b/backend/src/indexer/registry/registry-snapshot.service.spec.ts
@@ -1,0 +1,94 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { RegistrySnapshotService } from './registry-snapshot.service';
+import { RegistrySnapshotEntity } from '../entities/registry-snapshot.entity';
+
+const MOCK_REGISTRY = { contractId: 'C123', version: '1.0.0' };
+
+function makeRepo(overrides: Partial<ReturnType<typeof buildRepo>> = {}) {
+  return buildRepo(overrides);
+}
+
+function buildRepo(overrides: Record<string, unknown> = {}) {
+  return {
+    findOne: jest.fn().mockResolvedValue(null),
+    create: jest.fn().mockImplementation((v) => v),
+    save: jest.fn().mockImplementation((v) => Promise.resolve({ id: 1, ...v })),
+    find: jest.fn().mockResolvedValue([]),
+    ...overrides,
+  };
+}
+
+describe('RegistrySnapshotService', () => {
+  let service: RegistrySnapshotService;
+  let repo: ReturnType<typeof buildRepo>;
+
+  beforeEach(async () => {
+    repo = makeRepo();
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        RegistrySnapshotService,
+        { provide: getRepositoryToken(RegistrySnapshotEntity), useValue: repo },
+      ],
+    }).compile();
+
+    service = module.get(RegistrySnapshotService);
+  });
+
+  describe('save', () => {
+    it('persists a new snapshot when none exists', async () => {
+      const result = await service.save({
+        network: 'testnet',
+        contractId: 'C123',
+        registry: MOCK_REGISTRY,
+        capturedAtLedger: 100,
+      });
+
+      expect(repo.save).toHaveBeenCalledTimes(1);
+      expect(result.network).toBe('testnet');
+      expect(result.capturedAtLedger).toBe(100);
+    });
+
+    it('updates existing snapshot on second save', async () => {
+      const existing: Partial<RegistrySnapshotEntity> = { id: 5, capturedAtLedger: 50 };
+      repo.findOne.mockResolvedValue(existing);
+
+      await service.save({
+        network: 'testnet',
+        contractId: 'C123',
+        registry: MOCK_REGISTRY,
+        capturedAtLedger: 200,
+      });
+
+      const created = (repo.create as jest.Mock).mock.calls[0][0];
+      expect(created.id).toBe(5);
+      expect(created.capturedAtLedger).toBe(200);
+    });
+  });
+
+  describe('getLatest', () => {
+    it('returns null when no snapshot exists', async () => {
+      const result = await service.getLatest('testnet', 'C123');
+      expect(result).toBeNull();
+    });
+
+    it('returns the snapshot when found', async () => {
+      const snapshot = { id: 1, network: 'testnet', contractId: 'C123' };
+      repo.findOne.mockResolvedValue(snapshot);
+
+      const result = await service.getLatest('testnet', 'C123');
+      expect(result).toBe(snapshot);
+    });
+  });
+
+  describe('listByNetwork', () => {
+    it('returns snapshots for the given network', async () => {
+      const snapshots = [{ id: 1 }, { id: 2 }];
+      repo.find.mockResolvedValue(snapshots);
+
+      const result = await service.listByNetwork('testnet');
+      expect(result).toHaveLength(2);
+    });
+  });
+});

--- a/backend/src/indexer/registry/registry-snapshot.service.ts
+++ b/backend/src/indexer/registry/registry-snapshot.service.ts
@@ -1,0 +1,75 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { RegistrySnapshotEntity } from '../entities/registry-snapshot.entity';
+
+export interface RegistrySnapshotInput {
+  network: string;
+  contractId: string;
+  registry: Record<string, unknown>;
+  capturedAtLedger?: number;
+}
+
+@Injectable()
+export class RegistrySnapshotService {
+  private readonly logger = new Logger(RegistrySnapshotService.name);
+
+  constructor(
+    @InjectRepository(RegistrySnapshotEntity)
+    private readonly snapshotRepo: Repository<RegistrySnapshotEntity>,
+  ) {}
+
+  /**
+   * Persists (or updates) the registry snapshot for the given network and
+   * contract. Safe to call on every successful registry fetch — subsequent
+   * calls simply advance the ledger watermark.
+   */
+  async save(input: RegistrySnapshotInput): Promise<RegistrySnapshotEntity> {
+    const existing = await this.snapshotRepo.findOne({
+      where: { network: input.network, contractId: input.contractId },
+    });
+
+    const snapshot = this.snapshotRepo.create({
+      id: existing?.id,
+      network: input.network,
+      contractId: input.contractId,
+      registry: input.registry,
+      capturedAtLedger: input.capturedAtLedger ?? existing?.capturedAtLedger ?? 0,
+    });
+
+    const saved = await this.snapshotRepo.save(snapshot);
+
+    this.logger.log({
+      msg: 'indexer.registry_snapshot.saved',
+      network: input.network,
+      contractId: input.contractId,
+      capturedAtLedger: saved.capturedAtLedger,
+    });
+
+    return saved;
+  }
+
+  /**
+   * Returns the latest known registry snapshot for the given network and
+   * contract, or null if none has been persisted yet.
+   */
+  async getLatest(
+    network: string,
+    contractId: string,
+  ): Promise<RegistrySnapshotEntity | null> {
+    return this.snapshotRepo.findOne({
+      where: { network, contractId },
+      order: { updatedAt: 'DESC' },
+    });
+  }
+
+  /**
+   * Returns all snapshots for a network (useful for diagnostics).
+   */
+  async listByNetwork(network: string): Promise<RegistrySnapshotEntity[]> {
+    return this.snapshotRepo.find({
+      where: { network },
+      order: { updatedAt: 'DESC' },
+    });
+  }
+}

--- a/backend/src/indexer/reward-summary.controller.ts
+++ b/backend/src/indexer/reward-summary.controller.ts
@@ -1,0 +1,47 @@
+import { Controller, Get, Param, Query } from '@nestjs/common';
+import {
+  ApiOperation,
+  ApiParam,
+  ApiQuery,
+  ApiResponse,
+  ApiTags,
+} from '@nestjs/swagger';
+import { RewardSummaryService } from './reward-summary.service';
+import { RewardSummaryDto } from '../common/dto/reward-summary.dto';
+
+@ApiTags('Rewards')
+@Controller('rewards')
+export class RewardSummaryController {
+  constructor(private readonly rewardSummaryService: RewardSummaryService) {}
+
+  @Get(':player')
+  @ApiOperation({
+    summary: 'Get reward summary for a player',
+    description:
+      'Returns accrued, claimed, and pending-claim token totals derived ' +
+      'from on-chain session projection data. The "state" field signals ' +
+      'data availability: "unavailable" means no projection rows exist yet.',
+  })
+  @ApiParam({
+    name: 'player',
+    description: 'Stellar wallet address of the player',
+    example: 'GABC...XYZ',
+  })
+  @ApiQuery({
+    name: 'network',
+    description: 'Stellar network',
+    enum: ['testnet', 'mainnet'],
+    required: false,
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Reward summary returned successfully',
+    type: RewardSummaryDto,
+  })
+  async getRewardSummary(
+    @Param('player') player: string,
+    @Query('network') network: string = 'testnet',
+  ): Promise<RewardSummaryDto> {
+    return this.rewardSummaryService.getForPlayer(network, player);
+  }
+}

--- a/backend/src/indexer/reward-summary.service.spec.ts
+++ b/backend/src/indexer/reward-summary.service.spec.ts
@@ -1,0 +1,84 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { RewardSummaryService } from './reward-summary.service';
+import { SessionProjectionEntity } from './entities/session-projection.entity';
+
+function makeSession(
+  overrides: Partial<SessionProjectionEntity> = {},
+): SessionProjectionEntity {
+  return {
+    id: 1,
+    network: 'testnet',
+    sessionId: 'sess-1',
+    player: 'GABC',
+    dayId: 1,
+    status: 'Won',
+    attemptsUsed: 3,
+    finalized: true,
+    schemaVersion: 1,
+    updatedAt: new Date('2026-06-01T00:00:00Z'),
+    ...overrides,
+  } as SessionProjectionEntity;
+}
+
+describe('RewardSummaryService', () => {
+  let service: RewardSummaryService;
+  const repo = {
+    find: jest.fn(),
+  };
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        RewardSummaryService,
+        {
+          provide: getRepositoryToken(SessionProjectionEntity),
+          useValue: repo,
+        },
+      ],
+    }).compile();
+    service = module.get(RewardSummaryService);
+  });
+
+  it('returns unavailable state when no sessions exist', async () => {
+    repo.find.mockResolvedValue([]);
+    const result = await service.getForPlayer('testnet', 'GABC');
+    expect(result.state).toBe('unavailable');
+    expect(result.accrued).toBe(0);
+    expect(result.sessionCount).toBe(0);
+  });
+
+  it('correctly accrues points for won sessions', async () => {
+    repo.find.mockResolvedValue([
+      makeSession({ attemptsUsed: 1, status: 'Won' }), // 6 pts
+      makeSession({ attemptsUsed: 3, status: 'Won' }), // 4 pts
+      makeSession({ attemptsUsed: 6, status: 'Won' }), // 1 pt
+    ]);
+    const result = await service.getForPlayer('testnet', 'GABC');
+    expect(result.accrued).toBe(11);
+    expect(result.sessionCount).toBe(3);
+    expect(result.state).toBe('pending');
+  });
+
+  it('does not accrue points for lost sessions', async () => {
+    repo.find.mockResolvedValue([
+      makeSession({ attemptsUsed: 6, status: 'Lost' }),
+    ]);
+    const result = await service.getForPlayer('testnet', 'GABC');
+    expect(result.accrued).toBe(0);
+  });
+
+  it('calculates pendingClaim as accrued minus claimed', async () => {
+    repo.find.mockResolvedValue([makeSession({ attemptsUsed: 2, status: 'Won' })]);
+    const result = await service.getForPlayer('testnet', 'GABC');
+    expect(result.pendingClaim).toBe(result.accrued - result.claimed);
+  });
+
+  it('includes lastUpdatedAt from the most recent session', async () => {
+    const date = new Date('2026-06-26T10:00:00Z');
+    repo.find.mockResolvedValue([makeSession({ updatedAt: date })]);
+    const result = await service.getForPlayer('testnet', 'GABC');
+    expect(result.lastUpdatedAt).toBe(date.toISOString());
+  });
+});

--- a/backend/src/indexer/reward-summary.service.ts
+++ b/backend/src/indexer/reward-summary.service.ts
@@ -1,0 +1,66 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { SessionProjectionEntity } from './entities/session-projection.entity';
+import { RewardSummaryDto } from '../common/dto/reward-summary.dto';
+
+/**
+ * Points multiplier used to derive accrued tokens from attempts used.
+ * Sessions solved in fewer attempts score higher — this mirrors the
+ * on-chain scoring curve without requiring a live RPC call.
+ * MAX_ATTEMPTS (6) - attemptsUsed + 1 gives 6 pts for 1-attempt solves,
+ * down to 1 pt for 6-attempt solves.
+ */
+const MAX_ATTEMPTS = 6;
+const POINTS_PER_LOST_SESSION = 0;
+
+function attemptsToPoints(attemptsUsed: number, status: string): number {
+  const won = status.toLowerCase() === 'won' || status.toLowerCase() === 'finalized';
+  if (!won) return POINTS_PER_LOST_SESSION;
+  const clamped = Math.max(1, Math.min(attemptsUsed, MAX_ATTEMPTS));
+  return MAX_ATTEMPTS - clamped + 1;
+}
+
+@Injectable()
+export class RewardSummaryService {
+  constructor(
+    @InjectRepository(SessionProjectionEntity)
+    private readonly sessionsRepo: Repository<SessionProjectionEntity>,
+  ) {}
+
+  async getForPlayer(network: string, player: string): Promise<RewardSummaryDto> {
+    const sessions = await this.sessionsRepo.find({
+      where: { network, player, finalized: true },
+      order: { updatedAt: 'DESC' },
+    });
+
+    if (sessions.length === 0) {
+      return {
+        accrued: 0,
+        claimed: 0,
+        pendingClaim: 0,
+        sessionCount: 0,
+        state: 'unavailable',
+      };
+    }
+
+    const accrued = sessions.reduce(
+      (sum, s) => sum + attemptsToPoints(s.attemptsUsed, s.status),
+      0,
+    );
+
+    // claimed is tracked via 'reward_claimed' events — for now we surface 0
+    // and mark state as 'pending' so the frontend knows data exists but the
+    // claim read path is not yet wired to on-chain events.
+    const claimed = 0;
+
+    return {
+      accrued,
+      claimed,
+      pendingClaim: accrued - claimed,
+      sessionCount: sessions.length,
+      state: 'pending',
+      lastUpdatedAt: sessions[0]?.updatedAt?.toISOString(),
+    };
+  }
+}


### PR DESCRIPTION
## Summary

Closes #768 
Closes #769 
 Closes #770 
Closes #771

---

### BE-214 · Startup env validation for Soroban indexer and read API flows (#771)

- Added `backend/src/config/env.validation.ts` — class-validator schema covering all required vars: DB credentials, `JWT_SECRET`, `SOROBAN_RPC_URL`, `SOROBAN_CORE_GAME_CONTRACT_ID`, `SOROBAN_NETWORK`, and indexer tuning params.
- Wired into `ConfigModule.forRoot({ validate: validateEnv })` — app fails immediately on startup with a descriptive per-field error instead of crashing deep inside a request handler.
- Tests: `env.validation.spec.ts` (8 cases — missing required fields, bad enum values, defaults for optional fields).

### BE-213 · Persist contract registry snapshots for backend consumers (#770)

- New `RegistrySnapshotEntity` (`registry_snapshots` table) persists the Soroban registry JSON alongside `network`, `contractId`, and `capturedAtLedger`. Unique index on `(network, contractId)` — upserted on every successful fetch.
- `RegistrySnapshotService` exposes `save()`, `getLatest()`, and `listByNetwork()`. Registered in `IndexerModule` and exported for cross-module consumers.
- Tests: `registry-snapshot.service.spec.ts` (save new, update existing, getLatest, listByNetwork).

### BE-212 · Projection version metadata and migration strategy hooks (#769)

- Added `schemaVersion` column (default `1`) to `SessionProjectionEntity`. `ProjectionService` stamps `CURRENT_PROJECTION_VERSION` on every upsert so consumers can detect stale rows.
- New `projection-version.ts` defines `CURRENT_PROJECTION_VERSION`, the `ProjectionMigration` interface, `PROJECTION_MIGRATIONS` registry, and `getMigrationPath()` helper. Bump the version constant and add a migration entry to trigger a backfill pass.

### BE-211 · Reward accrual and claim summary read API (#768)

- `RewardSummaryDto` in `common/dto` surfaces `accrued`, `claimed`, `pendingClaim`, `sessionCount`, `state` (`available | pending | unavailable`), and `lastUpdatedAt`.
- `RewardSummaryService` computes accrued points from finalized `session_projections` rows using an attempts-to-points curve (fewer attempts = more points), matching the on-chain scoring model.
- `GET /rewards/:player?network=` via `RewardSummaryController`. Returns `state: "unavailable"` when no projection data exists yet.
- Tests: `reward-summary.service.spec.ts` (5 cases — unavailable state, points accrual, lost sessions, pendingClaim math, lastUpdatedAt).

## Test plan

- [ ] Start backend without required env vars → app should exit with a clear validation error listing missing fields
- [ ] Call `GET /rewards/:player` for an indexed player → accrued/pendingClaim populated correctly
- [ ] Call `GET /rewards/:player` for an unindexed player → `state: "unavailable"`
- [ ] Save a registry snapshot, call `getLatest()` → most recent snapshot returned
- [ ] Bump `CURRENT_PROJECTION_VERSION` and verify `ProjectionService` stamps the new version on upsert
- [ ] Run `npm run build && npm run typecheck && npm run lint:ci && npm run test:ci`