### PR TITLE
feat: DEVOPS-217 + QA-201/202/203 — CI write-permission check, snapshot policy, read-model mock, wallet reconnect suite

### DIFF
--- a/.github/workflows/ci-write-permission-check.yml
+++ b/.github/workflows/ci-write-permission-check.yml
@@ -1,0 +1,125 @@
+name: CI Runner Write-Permission Smoke Check
+
+# DEVOPS-217 (#796): Verify that CI runners can write to expected artifact and
+# cache directories. Catches permission regressions early before contributor
+# workflows that generate artifacts or caches silently fail.
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  write-permission-smoke-check:
+    name: Runner write-permission smoke check
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      # -----------------------------------------------------------------------
+      # Probe: workspace root is writable
+      # -----------------------------------------------------------------------
+      - name: Check workspace root is writable
+        run: |
+          PROBE="$GITHUB_WORKSPACE/.write-probe"
+          if touch "$PROBE" 2>/dev/null; then
+            echo "✅ workspace root writable: $GITHUB_WORKSPACE"
+            rm -f "$PROBE"
+          else
+            echo "::error::Runner cannot write to workspace root: $GITHUB_WORKSPACE"
+            echo "  Ensure the job does not run with a read-only filesystem or restricted runner policy."
+            exit 1
+          fi
+
+      # -----------------------------------------------------------------------
+      # Probe: standard artifact staging directory
+      # GitHub Actions uploads artifacts from paths the step writes to.
+      # We verify the runner can create and populate an artifacts sub-directory.
+      # -----------------------------------------------------------------------
+      - name: Check artifact staging directory is writable
+        run: |
+          ARTIFACT_DIR="$GITHUB_WORKSPACE/artifacts"
+          mkdir -p "$ARTIFACT_DIR"
+          PROBE="$ARTIFACT_DIR/.write-probe"
+          if touch "$PROBE" 2>/dev/null; then
+            echo "✅ artifact staging dir writable: $ARTIFACT_DIR"
+            rm -f "$PROBE"
+          else
+            echo "::error::Runner cannot write to artifact staging directory: $ARTIFACT_DIR"
+            echo "  Generated artifacts (build outputs, test reports) will fail to upload."
+            echo "  Check runner permissions or change the artifact output path."
+            exit 1
+          fi
+
+      # -----------------------------------------------------------------------
+      # Probe: npm/Node cache directory
+      # npm ci and similar commands cache downloads here. A read-only path
+      # causes silent cache misses and slower builds.
+      # -----------------------------------------------------------------------
+      - name: Check npm cache directory is writable
+        run: |
+          NPM_CACHE_DIR=$(npm config get cache 2>/dev/null || echo "$HOME/.npm")
+          mkdir -p "$NPM_CACHE_DIR"
+          PROBE="$NPM_CACHE_DIR/.write-probe"
+          if touch "$PROBE" 2>/dev/null; then
+            echo "✅ npm cache dir writable: $NPM_CACHE_DIR"
+            rm -f "$PROBE"
+          else
+            echo "::error::Runner cannot write to npm cache directory: $NPM_CACHE_DIR"
+            echo "  npm ci will not be able to cache packages. Set NPM_CONFIG_CACHE to a writable path."
+            exit 1
+          fi
+
+      # -----------------------------------------------------------------------
+      # Probe: Cargo/Rust cache directory
+      # cargo check and cargo build cache compiled artifacts here.
+      # -----------------------------------------------------------------------
+      - name: Check Cargo cache directory is writable
+        run: |
+          CARGO_HOME="${CARGO_HOME:-$HOME/.cargo}"
+          mkdir -p "$CARGO_HOME"
+          PROBE="$CARGO_HOME/.write-probe"
+          if touch "$PROBE" 2>/dev/null; then
+            echo "✅ Cargo cache dir writable: $CARGO_HOME"
+            rm -f "$PROBE"
+          else
+            echo "::error::Runner cannot write to Cargo cache directory: $CARGO_HOME"
+            echo "  Rust builds will not cache crates. Set CARGO_HOME to a writable path."
+            exit 1
+          fi
+
+      # -----------------------------------------------------------------------
+      # Probe: RUNNER_TEMP — used by actions/upload-artifact and other actions
+      # -----------------------------------------------------------------------
+      - name: Check RUNNER_TEMP is writable
+        run: |
+          PROBE="$RUNNER_TEMP/.write-probe"
+          if touch "$PROBE" 2>/dev/null; then
+            echo "✅ RUNNER_TEMP writable: $RUNNER_TEMP"
+            rm -f "$PROBE"
+          else
+            echo "::error::Runner cannot write to RUNNER_TEMP: $RUNNER_TEMP"
+            echo "  Many actions rely on RUNNER_TEMP for scratch space. This runner may have an unsupported configuration."
+            exit 1
+          fi
+
+      # -----------------------------------------------------------------------
+      # Summary: emit all probed paths to the job summary for audit trail
+      # -----------------------------------------------------------------------
+      - name: Write probe summary
+        if: always()
+        run: |
+          echo "## Write-Permission Smoke Check Results" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Path | Status |" >> "$GITHUB_STEP_SUMMARY"
+          echo "|------|--------|" >> "$GITHUB_STEP_SUMMARY"
+          echo "| \`$GITHUB_WORKSPACE\` (workspace root) | ✅ writable |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| \`$GITHUB_WORKSPACE/artifacts\` (artifact staging) | ✅ writable |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| \`$(npm config get cache 2>/dev/null || echo $HOME/.npm)\` (npm cache) | ✅ writable |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| \`${CARGO_HOME:-$HOME/.cargo}\` (Cargo cache) | ✅ writable |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| \`$RUNNER_TEMP\` (runner temp) | ✅ writable |" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "_Run on: $(date -u '+%Y-%m-%dT%H:%M:%SZ')_" >> "$GITHUB_STEP_SUMMARY"

--- a/docs/SNAPSHOT_UPDATE_POLICY.md
+++ b/docs/SNAPSHOT_UPDATE_POLICY.md
@@ -1,0 +1,116 @@
+# Soroban Contract Snapshot Update Policy
+
+> QA-201 (#798) — Covers: `soroban/contracts/*/test_snapshots/`
+
+## What are snapshots?
+
+The Soroban SDK test harness records contract ledger state after each test into
+`.json` files under `soroban/contracts/<contract>/test_snapshots/tests/`. Each
+file captures the full environment state — storage entries, events, and ledger
+metadata — at the point the test completes.
+
+Snapshots serve two purposes:
+
+1. **Regression detection** — a snapshot mismatch means the contract's on-chain
+   behaviour changed. CI catches this automatically on every PR.
+2. **Review audit trail** — committed snapshots make contract changes reviewable
+   without running Rust locally.
+
+---
+
+## When snapshots must be updated
+
+Update snapshots **only** when one of the following is true:
+
+| Trigger | Example |
+|---------|---------|
+| Storage key or type changed | Renamed a `DataKey` variant |
+| Event topic or payload changed | Added a field to `session_finalized` payload |
+| New contract entrypoint added | New `#[contractimpl]` function that writes storage |
+| Contract error code changed | Re-numbered a `#[contracterror]` variant |
+| Ledger configuration changed in a test | Changed `closes_at` math or `max_attempts` |
+
+**Do NOT update snapshots** to make a failing test green when you do not
+understand why it changed. A surprise snapshot diff is a signal to investigate,
+not to re-record.
+
+---
+
+## How to update snapshots
+
+### All contracts at once
+
+```bash
+cd soroban
+make update-snapshots
+```
+
+### A single contract
+
+```bash
+cd soroban
+make update-snapshots CONTRACT=core_game
+# other valid values: achievements, rewards, admin_registry
+```
+
+Both commands set the `SOROBAN_TEST_SNAPSHOT_UPDATE=1` environment variable,
+which causes the Soroban SDK test runner to overwrite existing snapshot files
+instead of asserting against them.
+
+---
+
+## Reviewer checklist
+
+When a PR touches snapshot files, reviewers must check **each changed file**:
+
+- [ ] The diff file name matches a test that was intentionally modified.
+- [ ] The changed fields (storage keys, event topics, payloads) correspond
+      exactly to the contract change described in the PR.
+- [ ] No **unrelated** snapshot files changed (snapshot churn from an
+      accidental `make update-snapshots` run is a red flag).
+- [ ] The updated snapshot is included in the **same commit** as the contract
+      source change — not in a follow-up "fix snapshots" commit.
+- [ ] The PR description explains *why* the snapshot changed, not just *that*
+      it changed.
+
+### Spotting accidental snapshot churn
+
+Accidental churn has these tell-tale signs:
+
+- Many snapshot files changed but the contract source diff is small or absent.
+- The `ledger_sequence` or `timestamp` fields changed but nothing else did —
+  this usually means a test used a non-deterministic ledger seed.
+- Snapshot files for contracts **not mentioned** in the PR description changed.
+
+If you see these patterns, ask the contributor to revert the snapshots and
+re-run only the affected contract with `make update-snapshots CONTRACT=<name>`.
+
+---
+
+## CI behaviour
+
+The `cargo test --workspace` job in CI runs **without**
+`SOROBAN_TEST_SNAPSHOT_UPDATE`. Any snapshot mismatch causes the job to fail
+with a diff printed to the log. This is intentional: snapshot updates must be
+explicit, not automatic.
+
+---
+
+## Snapshot file format
+
+Each snapshot file is named `<test_function_name>.<snapshot_index>.json`.
+The index starts at `1` and increments for each snapshot taken inside a single
+test. Key fields:
+
+```jsonc
+{
+  "env": {
+    "ledger": { "sequence_number": ..., "timestamp": ... },
+    "storage": { ... }       // all persistent + temporary storage entries
+  },
+  "events": [ ... ]          // contract events emitted during the test
+}
+```
+
+Do not hand-edit snapshot files. Always regenerate them with
+`make update-snapshots` to ensure consistency.

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -31,15 +31,16 @@
     "tailwind-merge": "^3.3.1"
   },
   "devDependencies": {
-    "@vitejs/plugin-react": "^5.1.0",
     "@eslint/eslintrc": "^3",
     "@tailwindcss/postcss": "^4",
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.3.0",
+    "@testing-library/user-event": "^14.5.2",
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",
     "@types/react-slick": "^0.23.13",
+    "@vitejs/plugin-react": "^5.1.0",
     "eslint": "^9",
     "eslint-config-next": "15.4.4",
     "jsdom": "^26.1.0",

--- a/frontend/src/test/read-model-mock.ts
+++ b/frontend/src/test/read-model-mock.ts
@@ -1,0 +1,212 @@
+/**
+ * read-model-mock.ts — QA-202 (#799)
+ *
+ * Reusable mocking helpers for backend read-model responses consumed by
+ * frontend hooks and route components.
+ *
+ * USAGE
+ * -----
+ * In any Vitest test file:
+ *
+ *   import { mockReadModel, resetReadModelMocks } from '@/test/read-model-mock';
+ *   import { afterEach, beforeEach } from 'vitest';
+ *
+ *   beforeEach(() => {
+ *     mockReadModel({
+ *       sessions: { sessions: [...], total: 1, skip: 0, take: 20 },
+ *       dayConfig: { dayId: 1, maxAttempts: 6, closesAt: 9999999999 },
+ *     });
+ *   });
+ *
+ *   afterEach(() => resetReadModelMocks());
+ *
+ * The helper stubs:
+ *   - `global.fetch` — used by route pages that call the backend REST API
+ *   - `@dewordle/soroban-sdk` — used by hooks that read contract state
+ *
+ * Both stubs are reset automatically when you call `resetReadModelMocks()`.
+ */
+
+import { vi, type Mock } from 'vitest';
+import type { DayConfig, Session } from '@dewordle/soroban-sdk';
+
+// ---------------------------------------------------------------------------
+// Backend REST response shapes (mirrors backend DTOs)
+// ---------------------------------------------------------------------------
+
+export interface SessionEntry {
+  sessionId: string;
+  player: string;
+  dayId: number;
+  status: 'InProgress' | 'Finalized' | 'Lost';
+  attemptsUsed: number;
+  finalized: boolean;
+  updatedAt: string;
+}
+
+export interface SessionHistoryResponse {
+  sessions: SessionEntry[];
+  total: number;
+  skip: number;
+  take: number;
+}
+
+export interface ReadModelFixtures {
+  /** Response returned for GET /api/v1/sessions */
+  sessions?: Partial<SessionHistoryResponse>;
+  /** DayConfig resolved by useDayConfig / CoreGameClient.getDayConfig */
+  dayConfig?: Partial<DayConfig> | null;
+  /** Session resolved by useSession / CoreGameClient.getSession */
+  session?: Partial<Session> | null;
+  /**
+   * Map of URL substrings → custom response bodies.
+   * Takes priority over the top-level `sessions` key when the fetch URL
+   * matches.
+   */
+  fetchOverrides?: Record<string, unknown>;
+}
+
+// ---------------------------------------------------------------------------
+// Default fixture factories
+// ---------------------------------------------------------------------------
+
+export function makeSessionEntry(overrides: Partial<SessionEntry> = {}): SessionEntry {
+  return {
+    sessionId: 'session-test-001',
+    player: 'GD5Y6Z7Q8W9X0A1B2C3D4E5F6G7H8I9J0K1L2M3N4O5P6Q7R8S9T0U1V2W3',
+    dayId: 1,
+    status: 'Finalized',
+    attemptsUsed: 4,
+    finalized: true,
+    updatedAt: '2026-06-01T12:00:00.000Z',
+    ...overrides,
+  };
+}
+
+export function makeSessionHistoryResponse(
+  overrides: Partial<SessionHistoryResponse> = {},
+): SessionHistoryResponse {
+  return {
+    sessions: [makeSessionEntry()],
+    total: 1,
+    skip: 0,
+    take: 20,
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// fetch stub
+// ---------------------------------------------------------------------------
+
+/**
+ * Creates a minimal `fetch` stub that returns JSON responses.
+ * Matches URL substrings to fixture data in order:
+ *   1. `fetchOverrides` keys (substring match)
+ *   2. `/sessions` → fixtures.sessions
+ *   3. Fallback: 404
+ */
+function buildFetchStub(fixtures: ReadModelFixtures): Mock {
+  return vi.fn().mockImplementation((url: string | URL | Request) => {
+    const urlStr = typeof url === 'string' ? url : url instanceof URL ? url.href : url.url;
+
+    // 1. Custom overrides take priority
+    if (fixtures.fetchOverrides) {
+      for (const [key, body] of Object.entries(fixtures.fetchOverrides)) {
+        if (urlStr.includes(key)) {
+          return Promise.resolve(
+            new Response(JSON.stringify(body), {
+              status: 200,
+              headers: { 'Content-Type': 'application/json' },
+            }),
+          );
+        }
+      }
+    }
+
+    // 2. Sessions endpoint
+    if (urlStr.includes('/sessions')) {
+      const body = makeSessionHistoryResponse(fixtures.sessions ?? {});
+      return Promise.resolve(
+        new Response(JSON.stringify(body), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        }),
+      );
+    }
+
+    // 3. Fallback
+    return Promise.resolve(new Response('Not Found', { status: 404 }));
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Soroban SDK stub
+// ---------------------------------------------------------------------------
+
+/**
+ * Stubs `@dewordle/soroban-sdk` so hooks that use `CoreGameClient` and
+ * `loadContractRegistry` receive controlled fixture data without hitting RPC.
+ */
+function stubSorobanSdk(fixtures: ReadModelFixtures): void {
+  vi.mock('@dewordle/soroban-sdk', async (importOriginal) => {
+    const actual = await importOriginal<typeof import('@dewordle/soroban-sdk')>();
+    return {
+      ...actual,
+      loadContractRegistry: vi.fn().mockResolvedValue({
+        network: 'testnet',
+        contracts: {
+          core_game: 'CCJZ5P5Z5P5Z5P5Z5P5Z5P5Z5P5Z5P5Z5P5Z5P5Z5',
+          admin_registry: 'CCJZ5P5Z5P5Z5P5Z5P5Z5P5Z5P5Z5P5Z5P5Z5P5Z5',
+          rewards: 'CCJZ5P5Z5P5Z5P5Z5P5Z5P5Z5P5Z5P5Z5P5Z5P5Z5',
+          achievements: 'CCJZ5P5Z5P5Z5P5Z5P5Z5P5Z5P5Z5P5Z5P5Z5P5Z5',
+        },
+      }),
+      CoreGameClient: {
+        fromRegistry: vi.fn().mockReturnValue({
+          getDayConfig: vi.fn().mockResolvedValue(fixtures.dayConfig ?? null),
+          getSession: vi.fn().mockResolvedValue(fixtures.session ?? null),
+        }),
+      },
+    };
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/** Active fetch mock, kept so callers can assert against it. */
+let _fetchMock: Mock | null = null;
+
+/**
+ * Install fetch + Soroban SDK mocks for the given fixtures.
+ * Call in `beforeEach`. Pair with `resetReadModelMocks` in `afterEach`.
+ */
+export function mockReadModel(fixtures: ReadModelFixtures = {}): void {
+  _fetchMock = buildFetchStub(fixtures);
+  vi.stubGlobal('fetch', _fetchMock);
+  stubSorobanSdk(fixtures);
+}
+
+/**
+ * Returns the active fetch mock so tests can assert call counts and arguments.
+ *
+ * Example:
+ *   expect(getReadModelFetchMock()).toHaveBeenCalledWith(
+ *     expect.stringContaining('/sessions'),
+ *   );
+ */
+export function getReadModelFetchMock(): Mock {
+  if (!_fetchMock) throw new Error('Call mockReadModel() before getReadModelFetchMock()');
+  return _fetchMock;
+}
+
+/**
+ * Reset all read-model mocks. Call in `afterEach`.
+ */
+export function resetReadModelMocks(): void {
+  vi.unstubAllGlobals();
+  vi.clearAllMocks();
+  _fetchMock = null;
+}

--- a/frontend/src/test/sessions-page.spec.tsx
+++ b/frontend/src/test/sessions-page.spec.tsx
@@ -1,0 +1,145 @@
+/**
+ * sessions-page.spec.tsx — QA-202 (#799)
+ *
+ * Demonstrates the read-model mock library in a route-level component test.
+ * The sessions page fetches from the backend REST API; here we stub `fetch`
+ * via mockReadModel so no network request is made.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import {
+  mockReadModel,
+  resetReadModelMocks,
+  getReadModelFetchMock,
+  makeSessionEntry,
+  makeSessionHistoryResponse,
+} from './read-model-mock';
+
+// ---------------------------------------------------------------------------
+// Mock Next.js navigation (not used in tests but imported by the page)
+// ---------------------------------------------------------------------------
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: vi.fn(), replace: vi.fn() }),
+  usePathname: () => '/',
+}));
+
+// ---------------------------------------------------------------------------
+// Mock the wallet hook so the page renders without a real provider
+// ---------------------------------------------------------------------------
+vi.mock('@/hooks/useStellarWallet', () => ({
+  useStellarWallet: () => ({
+    connected: false,
+    address: undefined,
+    readOnly: true,
+    connect: vi.fn(),
+    disconnect: vi.fn(),
+    status: { id: '', state: 'idle' },
+  }),
+}));
+
+// Lazy import after mocks are registered
+async function importPage() {
+  const mod = await import('@/app/sessions/page');
+  return mod.default;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('SessionsPage — read-model mock library (QA-202)', () => {
+  beforeEach(() => {
+    mockReadModel({
+      sessions: makeSessionHistoryResponse({
+        sessions: [
+          makeSessionEntry({ dayId: 7, status: 'Finalized', attemptsUsed: 3 }),
+          makeSessionEntry({
+            sessionId: 'session-test-002',
+            dayId: 8,
+            status: 'Lost',
+            attemptsUsed: 6,
+          }),
+        ],
+        total: 2,
+      }),
+    });
+  });
+
+  afterEach(() => {
+    resetReadModelMocks();
+    vi.resetModules();
+  });
+
+  it('renders the page heading', async () => {
+    const Page = await importPage();
+    render(<Page />);
+    expect(screen.getByRole('heading', { name: /session history/i })).toBeDefined();
+  });
+
+  it('fetches sessions from the API on mount', async () => {
+    const Page = await importPage();
+    render(<Page />);
+    await waitFor(() => {
+      const calls = getReadModelFetchMock().mock.calls;
+      expect(calls.length).toBeGreaterThan(0);
+      const firstUrl = String(calls[0]?.[0] ?? '');
+      expect(firstUrl).toContain('/sessions');
+    });
+  });
+
+  it('renders session rows returned by the API', async () => {
+    const Page = await importPage();
+    render(<Page />);
+    await waitFor(() => {
+      expect(screen.getByText('Day #7')).toBeDefined();
+      expect(screen.getByText('Day #8')).toBeDefined();
+    });
+  });
+
+  it('shows read-only banner and connect-wallet prompt when wallet is disconnected', async () => {
+    const Page = await importPage();
+    render(<Page />);
+    await waitFor(() => {
+      expect(screen.getByText(/connect wallet/i)).toBeDefined();
+    });
+  });
+
+  it('renders empty state when the API returns no sessions', async () => {
+    resetReadModelMocks();
+    mockReadModel({
+      sessions: makeSessionHistoryResponse({ sessions: [], total: 0 }),
+    });
+    const Page = await importPage();
+    render(<Page />);
+    await waitFor(() => {
+      expect(screen.getByText(/no sessions found/i)).toBeDefined();
+    });
+  });
+
+  it('shows error state when the API returns a non-ok response', async () => {
+    resetReadModelMocks();
+    // Override fetch to reject so the page's error handler is triggered
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockRejectedValue(new Error('Failed to fetch sessions')),
+    );
+    const Page = await importPage();
+    render(<Page />);
+    await waitFor(() => {
+      expect(screen.getByText(/failed to load/i)).toBeDefined();
+    });
+  });
+
+  it('passes correct pagination params (skip=0, take=20) on initial load', async () => {
+    const Page = await importPage();
+    render(<Page />);
+    await waitFor(() => {
+      const calls = getReadModelFetchMock().mock.calls;
+      const firstUrl = String(calls[0]?.[0] ?? '');
+      expect(firstUrl).toContain('skip=0');
+      expect(firstUrl).toContain('take=20');
+    });
+  });
+});

--- a/frontend/src/test/wallet-reconnect.spec.tsx
+++ b/frontend/src/test/wallet-reconnect.spec.tsx
@@ -1,0 +1,512 @@
+/**
+ * wallet-reconnect.spec.tsx — QA-203 (#800)
+ *
+ * Regression suite for wallet disconnect, reconnect, account switch, and
+ * resumed action flows inside StellarWalletProvider / useStellarWallet.
+ *
+ * No real wallet extension is used. Freighter's browser API and
+ * stellarWalletsKit are stubbed via vi.stubGlobal.
+ *
+ * Unsupported scenarios discovered during test design are documented at the
+ * bottom of this file.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { render, screen, act, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { type ReactNode } from 'react';
+
+// ---------------------------------------------------------------------------
+// Minimal freighterApi stub factory
+// ---------------------------------------------------------------------------
+
+interface FreighterApiStub {
+  isConnected: ReturnType<typeof vi.fn>;
+  getAddress: ReturnType<typeof vi.fn>;
+}
+
+function makeFreighterStub(address: string, connected = true): FreighterApiStub {
+  return {
+    isConnected: vi.fn().mockResolvedValue({ isConnected: connected }),
+    getAddress: vi.fn().mockResolvedValue({ address }),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Wallet display component
+// ---------------------------------------------------------------------------
+
+import { StellarWalletProvider } from '@/providers/stellar-wallet-provider';
+import { useStellarWallet } from '@/hooks/useStellarWallet';
+
+function WalletDisplay() {
+  const wallet = useStellarWallet();
+  return (
+    <div>
+      <span data-testid="connected">{String(wallet.connected)}</span>
+      <span data-testid="address">{wallet.address ?? 'none'}</span>
+      <span data-testid="network">{wallet.network}</span>
+      <span data-testid="tx-state">{wallet.status.state}</span>
+      <span data-testid="read-only">{String(wallet.readOnly)}</span>
+      <button onClick={() => wallet.connect().catch(() => { /* connect errors are handled by the provider */ })} data-testid="btn-connect">
+        Connect
+      </button>
+      <button onClick={() => wallet.disconnect()} data-testid="btn-disconnect">
+        Disconnect
+      </button>
+      <button
+        onClick={() => wallet.switchNetwork('mainnet')}
+        data-testid="btn-switch-mainnet"
+      >
+        Switch Mainnet
+      </button>
+    </div>
+  );
+}
+
+function Wrapper({ children }: { children: ReactNode }) {
+  return <StellarWalletProvider>{children}</StellarWalletProvider>;
+}
+
+function renderWallet() {
+  return render(
+    <Wrapper>
+      <WalletDisplay />
+    </Wrapper>,
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const ADDR_A = 'GABC1111111111111111111111111111111111111111111111111111111111';
+const ADDR_B = 'GXYZ9999999999999999999999999999999999999999999999999999999999';
+
+function stubFreighter(address: string, connected = true) {
+  const stub = makeFreighterStub(address, connected);
+  vi.stubGlobal('freighterApi', stub);
+  vi.stubGlobal('stellarWalletsKit', undefined);
+  return stub;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('Wallet reconnect regression suite (QA-203)', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+  });
+
+  // -------------------------------------------------------------------------
+  // Initial state
+  // -------------------------------------------------------------------------
+
+  describe('initial state', () => {
+    it('starts disconnected with no address', () => {
+      renderWallet();
+      expect(screen.getByTestId('connected').textContent).toBe('false');
+      expect(screen.getByTestId('address').textContent).toBe('none');
+    });
+
+    it('starts in read-only mode', () => {
+      renderWallet();
+      expect(screen.getByTestId('read-only').textContent).toBe('true');
+    });
+
+    it('defaults to testnet', () => {
+      renderWallet();
+      expect(screen.getByTestId('network').textContent).toBe('testnet');
+    });
+
+    it('tx status defaults to idle', () => {
+      renderWallet();
+      expect(screen.getByTestId('tx-state').textContent).toBe('idle');
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Connect flow
+  // -------------------------------------------------------------------------
+
+  describe('connect flow', () => {
+    it('connects and sets address via Freighter', async () => {
+      stubFreighter(ADDR_A);
+      renderWallet();
+      await userEvent.click(screen.getByTestId('btn-connect'));
+      await waitFor(() => {
+        expect(screen.getByTestId('connected').textContent).toBe('true');
+        expect(screen.getByTestId('address').textContent).toBe(ADDR_A);
+      });
+    });
+
+    it('leaves read-only false after connect', async () => {
+      stubFreighter(ADDR_A);
+      renderWallet();
+      await userEvent.click(screen.getByTestId('btn-connect'));
+      await waitFor(() => {
+        expect(screen.getByTestId('read-only').textContent).toBe('false');
+      });
+    });
+
+    it('stays disconnected when Freighter isConnected returns false', async () => {
+      stubFreighter(ADDR_A, false /* isConnected = false */);
+      renderWallet();
+      await userEvent.click(screen.getByTestId('btn-connect'));
+      // connect() throws internally but ensureConnected catches; state stays false
+      await waitFor(() => {
+        expect(screen.getByTestId('connected').textContent).toBe('false');
+      });
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Disconnect flow
+  // -------------------------------------------------------------------------
+
+  describe('disconnect flow', () => {
+    beforeEach(async () => {
+      stubFreighter(ADDR_A);
+      renderWallet();
+      await userEvent.click(screen.getByTestId('btn-connect'));
+      await waitFor(() => expect(screen.getByTestId('connected').textContent).toBe('true'));
+    });
+
+    it('clears connected and address on disconnect', async () => {
+      await userEvent.click(screen.getByTestId('btn-disconnect'));
+      await waitFor(() => {
+        expect(screen.getByTestId('connected').textContent).toBe('false');
+        expect(screen.getByTestId('address').textContent).toBe('none');
+      });
+    });
+
+    it('resets tx status to idle on disconnect', async () => {
+      await userEvent.click(screen.getByTestId('btn-disconnect'));
+      await waitFor(() => {
+        expect(screen.getByTestId('tx-state').textContent).toBe('idle');
+      });
+    });
+
+    it('restores read-only mode after disconnect', async () => {
+      await userEvent.click(screen.getByTestId('btn-disconnect'));
+      await waitFor(() => {
+        expect(screen.getByTestId('read-only').textContent).toBe('true');
+      });
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Reconnect flow
+  // -------------------------------------------------------------------------
+
+  describe('reconnect flow', () => {
+    it('reconnects to the same account after disconnect', async () => {
+      stubFreighter(ADDR_A);
+      renderWallet();
+
+      await userEvent.click(screen.getByTestId('btn-connect'));
+      await waitFor(() => expect(screen.getByTestId('connected').textContent).toBe('true'));
+
+      await userEvent.click(screen.getByTestId('btn-disconnect'));
+      await waitFor(() => expect(screen.getByTestId('connected').textContent).toBe('false'));
+
+      await userEvent.click(screen.getByTestId('btn-connect'));
+      await waitFor(() => {
+        expect(screen.getByTestId('connected').textContent).toBe('true');
+        expect(screen.getByTestId('address').textContent).toBe(ADDR_A);
+      });
+    });
+
+    it('reconnects to a different account after disconnect', async () => {
+      stubFreighter(ADDR_A);
+      renderWallet();
+
+      await userEvent.click(screen.getByTestId('btn-connect'));
+      await waitFor(() => expect(screen.getByTestId('address').textContent).toBe(ADDR_A));
+
+      await userEvent.click(screen.getByTestId('btn-disconnect'));
+      await waitFor(() => expect(screen.getByTestId('connected').textContent).toBe('false'));
+
+      stubFreighter(ADDR_B);
+      await userEvent.click(screen.getByTestId('btn-connect'));
+      await waitFor(() => {
+        expect(screen.getByTestId('connected').textContent).toBe('true');
+        expect(screen.getByTestId('address').textContent).toBe(ADDR_B);
+      });
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Account switch detection (focus / visibilitychange polling)
+  // -------------------------------------------------------------------------
+
+  describe('account switch detection', () => {
+    it('detects an account switch on window focus', async () => {
+      const stub = stubFreighter(ADDR_A);
+      renderWallet();
+
+      await userEvent.click(screen.getByTestId('btn-connect'));
+      await waitFor(() => expect(screen.getByTestId('address').textContent).toBe(ADDR_A));
+
+      // Simulate user switching accounts in Freighter then returning to the tab
+      stub.getAddress.mockResolvedValue({ address: ADDR_B });
+
+      await act(async () => {
+        window.dispatchEvent(new Event('focus'));
+        // Flush the microtask that checkForAccountSwitch schedules
+        await new Promise((r) => setTimeout(r, 0));
+      });
+
+      await waitFor(() => {
+        expect(screen.getByTestId('address').textContent).toBe(ADDR_B);
+      });
+    });
+
+    it('detects an account switch on visibilitychange', async () => {
+      const stub = stubFreighter(ADDR_A);
+      renderWallet();
+
+      await userEvent.click(screen.getByTestId('btn-connect'));
+      await waitFor(() => expect(screen.getByTestId('address').textContent).toBe(ADDR_A));
+
+      stub.getAddress.mockResolvedValue({ address: ADDR_B });
+
+      await act(async () => {
+        document.dispatchEvent(new Event('visibilitychange'));
+        await new Promise((r) => setTimeout(r, 0));
+      });
+
+      await waitFor(() => {
+        expect(screen.getByTestId('address').textContent).toBe(ADDR_B);
+      });
+    });
+
+    it('notifies onAccountSwitch listeners when address changes', async () => {
+      const stub = stubFreighter(ADDR_A);
+
+      const switchCallback = vi.fn();
+
+      function ListenerComponent() {
+        const wallet = useStellarWallet();
+        // Register on first render — the hook returns an unsubscribe fn
+        wallet.onAccountSwitch(switchCallback);
+        return null;
+      }
+
+      render(
+        <Wrapper>
+          <WalletDisplay />
+          <ListenerComponent />
+        </Wrapper>,
+      );
+
+      await userEvent.click(screen.getByTestId('btn-connect'));
+      await waitFor(() => expect(screen.getByTestId('connected').textContent).toBe('true'));
+
+      stub.getAddress.mockResolvedValue({ address: ADDR_B });
+
+      await act(async () => {
+        window.dispatchEvent(new Event('focus'));
+        await new Promise((r) => setTimeout(r, 0));
+      });
+
+      await waitFor(() => {
+        expect(screen.getByTestId('address').textContent).toBe(ADDR_B);
+        expect(switchCallback).toHaveBeenCalledWith(ADDR_B);
+      });
+    });
+
+    it('does not poll getAddress when wallet is disconnected', async () => {
+      const stub = stubFreighter(ADDR_A);
+      renderWallet();
+      // Do NOT connect
+
+      await act(async () => {
+        window.dispatchEvent(new Event('focus'));
+        await new Promise((r) => setTimeout(r, 0));
+      });
+
+      expect(stub.getAddress).not.toHaveBeenCalled();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Network switch flow
+  // -------------------------------------------------------------------------
+
+  describe('network switch flow', () => {
+    it('switches to mainnet', async () => {
+      renderWallet();
+      await userEvent.click(screen.getByTestId('btn-switch-mainnet'));
+      await waitFor(() => {
+        expect(screen.getByTestId('network').textContent).toBe('mainnet');
+      });
+    });
+
+    it('resets tx status to idle when network switches', async () => {
+      stubFreighter(ADDR_A);
+      renderWallet();
+      await userEvent.click(screen.getByTestId('btn-connect'));
+      await waitFor(() => expect(screen.getByTestId('connected').textContent).toBe('true'));
+
+      await userEvent.click(screen.getByTestId('btn-switch-mainnet'));
+      await waitFor(() => {
+        expect(screen.getByTestId('tx-state').textContent).toBe('idle');
+      });
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Resumed action flow — ensureConnected
+  // -------------------------------------------------------------------------
+
+  describe('resumed action flow — ensureConnected', () => {
+    it('returns true immediately when already connected', async () => {
+      stubFreighter(ADDR_A);
+
+      let result: boolean | undefined;
+      function EnsureTest() {
+        const wallet = useStellarWallet();
+        return (
+          <button
+            data-testid="btn-ensure"
+            onClick={async () => {
+              result = await wallet.ensureConnected();
+            }}
+          >
+            Ensure
+          </button>
+        );
+      }
+
+      render(
+        <Wrapper>
+          <WalletDisplay />
+          <EnsureTest />
+        </Wrapper>,
+      );
+
+      await userEvent.click(screen.getByTestId('btn-connect'));
+      await waitFor(() => expect(screen.getByTestId('connected').textContent).toBe('true'));
+
+      await userEvent.click(screen.getByTestId('btn-ensure'));
+      await waitFor(() => expect(result).toBe(true));
+    });
+
+    it('connects and returns true when disconnected but Freighter is available', async () => {
+      stubFreighter(ADDR_A);
+
+      let result: boolean | undefined;
+      function EnsureTest() {
+        const wallet = useStellarWallet();
+        return (
+          <button
+            data-testid="btn-ensure"
+            onClick={async () => {
+              result = await wallet.ensureConnected();
+            }}
+          >
+            Ensure
+          </button>
+        );
+      }
+
+      render(
+        <Wrapper>
+          <WalletDisplay />
+          <EnsureTest />
+        </Wrapper>,
+      );
+
+      await userEvent.click(screen.getByTestId('btn-ensure'));
+      await waitFor(() => {
+        expect(result).toBe(true);
+        expect(screen.getByTestId('connected').textContent).toBe('true');
+      });
+    });
+
+    it('returns false when no wallet extension is available', async () => {
+      vi.stubGlobal('freighterApi', undefined);
+      vi.stubGlobal('stellarWalletsKit', undefined);
+
+      let result: boolean | undefined;
+      function EnsureTest() {
+        const wallet = useStellarWallet();
+        return (
+          <button
+            data-testid="btn-ensure"
+            onClick={async () => {
+              result = await wallet.ensureConnected();
+            }}
+          >
+            Ensure
+          </button>
+        );
+      }
+
+      render(
+        <Wrapper>
+          <WalletDisplay />
+          <EnsureTest />
+        </Wrapper>,
+      );
+
+      await userEvent.click(screen.getByTestId('btn-ensure'));
+      await waitFor(() => expect(result).toBe(false));
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // WalletKit (stellarWalletsKit) path
+  // -------------------------------------------------------------------------
+
+  describe('WalletKit connect path', () => {
+    it('connects via stellarWalletsKit when available', async () => {
+      vi.stubGlobal('freighterApi', undefined);
+      vi.stubGlobal('stellarWalletsKit', {
+        openModal: vi.fn().mockImplementation(
+          async (params: {
+            onWalletSelected: (wallet: {
+              getAddress: () => Promise<{ address: string }>;
+            }) => Promise<void>;
+          }) => {
+            await params.onWalletSelected({
+              getAddress: async () => ({ address: ADDR_B }),
+            });
+          },
+        ),
+      });
+
+      renderWallet();
+      await userEvent.click(screen.getByTestId('btn-connect'));
+      await waitFor(() => {
+        expect(screen.getByTestId('connected').textContent).toBe('true');
+        expect(screen.getByTestId('address').textContent).toBe(ADDR_B);
+      });
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// UNSUPPORTED SCENARIOS — documented per QA-203 acceptance criteria
+// ---------------------------------------------------------------------------
+//
+// 1. Freighter extension removal mid-session
+//    The provider polls on focus/visibilitychange but has no mechanism to
+//    detect extension uninstall while the tab is active. A "health check"
+//    polling interval would be needed to cover this.
+//
+// 2. Hardware wallet (Ledger) account switch
+//    Ledger devices don't expose event-driven account-switch APIs. Detecting
+//    a Ledger switch requires a polling loop not yet implemented in the provider.
+//
+// 3. WalletKit account switch events
+//    stellarWalletsKit does not emit DOM events for account switches. The
+//    provider only polls freighterApi.getAddress; WalletKit sessions are
+//    unmonitored until the user triggers a focus event.
+//
+// 4. Mobile wallet deep-link reconnect
+//    WalletConnect-style deep-link wallets have an async reconnect handshake
+//    not modelled in the current provider implementation.

--- a/soroban/Makefile
+++ b/soroban/Makefile
@@ -1,4 +1,4 @@
-.PHONY: check fmt test build-wasm
+.PHONY: check fmt test build-wasm update-snapshots diff-snapshots
 
 check:
 	cargo check --workspace
@@ -11,3 +11,47 @@ test:
 
 build-wasm:
 	cargo build --workspace --target wasm32-unknown-unknown --release
+
+# ---------------------------------------------------------------------------
+# Snapshot management — QA-201 (#798)
+# ---------------------------------------------------------------------------
+
+## update-snapshots: Intentionally regenerate all soroban-sdk test snapshots.
+##
+## Usage:
+##   make update-snapshots                  # update all contracts
+##   make update-snapshots CONTRACT=core_game  # update one contract
+##
+## When to run:
+##   Run ONLY after a deliberate change to contract storage layout, event
+##   payloads, or type definitions. Never run just to make a failing test pass
+##   without understanding why the snapshot changed.
+##
+## After running:
+##   1. Review every changed .json file with `git diff soroban/contracts/`.
+##   2. Confirm each change matches the intended contract modification.
+##   3. Include the updated snapshots in the same commit as the contract change.
+##
+## See docs/SNAPSHOT_UPDATE_POLICY.md for the full review checklist.
+update-snapshots:
+ifdef CONTRACT
+	SOROBAN_TEST_SNAPSHOT_UPDATE=1 cargo test -p $(CONTRACT) -- --include-ignored 2>&1 | tee /tmp/snapshot-update-$(CONTRACT).log
+	@echo ""
+	@echo "Snapshots updated for contract: $(CONTRACT)"
+	@echo "Review changes with: git diff soroban/contracts/$(CONTRACT)/test_snapshots/"
+else
+	SOROBAN_TEST_SNAPSHOT_UPDATE=1 cargo test --workspace -- --include-ignored 2>&1 | tee /tmp/snapshot-update-all.log
+	@echo ""
+	@echo "All snapshots updated."
+	@echo "Review changes with: git diff soroban/contracts/*/test_snapshots/"
+endif
+
+## diff-snapshots: Show a summary of which snapshot files have changed.
+##
+## Use this before committing to get a quick audit of which tests were affected.
+diff-snapshots:
+	@git diff --stat -- 'soroban/contracts/*/test_snapshots/' | grep -E '\.(json)' || echo "(no snapshot changes)"
+	@echo ""
+	@git diff --name-only -- 'soroban/contracts/*/test_snapshots/' | while read f; do \
+	  echo "--- Changed snapshot: $$f"; \
+	done


### PR DESCRIPTION
## Summary

Implements four Stellar Wave issues across the DEVOPS and QA tracks.

---

### #796 — DEVOPS-217: CI runner write-permission smoke checks

Added `.github/workflows/ci-write-permission-check.yml`. The workflow runs on every PR and push to `main` and probes five writable paths expected by contributor workflows:

- Workspace root (`$GITHUB_WORKSPACE`)
- Artifact staging directory
- npm cache directory
- Cargo/Rust cache directory (`$CARGO_HOME`)
- `$RUNNER_TEMP`

Each probe fails with an actionable error message that tells contributors exactly which path is unavailable and how to fix it. A step summary table is written for audit trail.

Closes #796

---

### #798 — QA-201: Soroban contract snapshot update policy harness

`soroban/Makefile` gains two new targets:

- `make update-snapshots` — regenerates all contract snapshots (sets `SOROBAN_TEST_SNAPSHOT_UPDATE=1`); accepts optional `CONTRACT=<name>` to scope to a single contract
- `make diff-snapshots` — summarises which snapshot files have changed before committing

`docs/SNAPSHOT_UPDATE_POLICY.md` documents:
- When snapshots must (and must not) be updated
- Step-by-step update instructions
- Reviewer checklist for distinguishing valid fixture changes from accidental churn
- Signs of accidental snapshot churn
- Snapshot JSON format reference

Closes #798

---

### #799 — QA-202: Frontend read API mocking library

Added `frontend/src/test/read-model-mock.ts` providing:

- `mockReadModel(fixtures)` — installs a `fetch` stub and `@dewordle/soroban-sdk` mock in one call; supports per-URL overrides via `fetchOverrides`
- `resetReadModelMocks()` — cleans up all stubs (call in `afterEach`)
- `getReadModelFetchMock()` — returns the active fetch mock for call assertions
- `makeSessionEntry` / `makeSessionHistoryResponse` — fixture factories

Demonstrated in `frontend/src/test/sessions-page.spec.tsx` (7 route-level tests covering heading rendering, fetch call verification, session rows, read-only banner, empty state, error state, and pagination params).

Closes #799

---

### #800 — QA-203: Wallet reconnect regression suite

Added `frontend/src/test/wallet-reconnect.spec.tsx` (22 tests) covering:

- **Initial state**: disconnected, read-only, testnet, idle tx status
- **Connect flow**: Freighter connect, address set, read-only cleared, failure when `isConnected` is false
- **Disconnect flow**: state cleared, tx reset, read-only restored
- **Reconnect flow**: same account, different account
- **Account switch detection**: `window focus` event, `visibilitychange` event, `onAccountSwitch` listener notification, no polling when disconnected
- **Network switch**: mainnet switch, tx status reset
- **Resumed action — ensureConnected**: returns true when already connected, connects and returns true when disconnected, returns false when no extension available
- **WalletKit path**: connect via `stellarWalletsKit.openModal`

Unsupported scenarios (Freighter extension removal, Ledger account switch, WalletKit switch events, mobile deep-link reconnect) are documented inline.

Closes #800

---

## Test results

```
Test Files  7 passed (7)
     Tests  77 passed (77)
```

No previously-passing tests were broken.

## Files changed

| File | Purpose |
|------|---------|
| `.github/workflows/ci-write-permission-check.yml` | #796 — write-permission smoke check workflow |
| `soroban/Makefile` | #798 — `update-snapshots` and `diff-snapshots` targets |
| `docs/SNAPSHOT_UPDATE_POLICY.md` | #798 — snapshot update policy and reviewer checklist |
| `frontend/src/test/read-model-mock.ts` | #799 — reusable read-model mock library |
| `frontend/src/test/sessions-page.spec.tsx` | #799 — route-level demo of mock library |
| `frontend/src/test/wallet-reconnect.spec.tsx` | #800 — wallet reconnect regression suite |
