### PR TITLE
qa: add contract registry drift snapshots and read-model performance smoke benchmarks

### DIFF
--- a/backend/src/indexer/performance-smoke.spec.ts
+++ b/backend/src/indexer/performance-smoke.spec.ts
@@ -1,0 +1,116 @@
+/**
+ * QA-217: Read-model endpoint performance smoke benchmarks.
+ *
+ * Scope: measures wall-clock latency of key projection-backed service methods
+ * under a synchronous mock so timings reflect pure application logic overhead.
+ * These are NOT load tests; they establish a deterministic regression baseline
+ * that maintainers can run locally or in CI to catch accidental quadratic scans
+ * or unbounded loops introduced during refactors.
+ *
+ * Thresholds (mocked I/O, no DB):
+ *   - single-player summary: < 20 ms
+ *   - batch of 50 sessions: < 50 ms
+ */
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { RewardSummaryService } from './reward-summary.service';
+import { SessionProjectionEntity } from './entities/session-projection.entity';
+
+function makeSession(
+  overrides: Partial<SessionProjectionEntity> = {},
+): SessionProjectionEntity {
+  return {
+    id: 1,
+    network: 'testnet',
+    sessionId: 'sess-1',
+    player: 'GABC',
+    dayId: 1,
+    status: 'Won',
+    attemptsUsed: 3,
+    finalized: true,
+    schemaVersion: 1,
+    updatedAt: new Date('2026-01-01T00:00:00Z'),
+    ...overrides,
+  } as SessionProjectionEntity;
+}
+
+function makeBatch(count: number): SessionProjectionEntity[] {
+  return Array.from({ length: count }, (_, i) =>
+    makeSession({
+      id: i + 1,
+      sessionId: `sess-${i + 1}`,
+      attemptsUsed: (i % 6) + 1,
+      status: i % 4 === 0 ? 'Lost' : 'Won',
+    }),
+  );
+}
+
+describe('QA-217: RewardSummaryService — performance smoke benchmarks', () => {
+  let service: RewardSummaryService;
+  const repo = { find: jest.fn() };
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        RewardSummaryService,
+        { provide: getRepositoryToken(SessionProjectionEntity), useValue: repo },
+      ],
+    }).compile();
+    service = module.get(RewardSummaryService);
+  });
+
+  it('single-player summary completes within 20 ms (mocked I/O)', async () => {
+    repo.find.mockResolvedValue([makeSession()]);
+
+    const t0 = Date.now();
+    await service.getForPlayer('testnet', 'GABC');
+    const elapsed = Date.now() - t0;
+
+    expect(elapsed).toBeLessThan(20);
+  });
+
+  it('batch of 50 sessions completes within 50 ms (mocked I/O)', async () => {
+    repo.find.mockResolvedValue(makeBatch(50));
+
+    const t0 = Date.now();
+    await service.getForPlayer('testnet', 'GABC');
+    const elapsed = Date.now() - t0;
+
+    expect(elapsed).toBeLessThan(50);
+  });
+
+  it('empty-player summary completes within 20 ms', async () => {
+    repo.find.mockResolvedValue([]);
+
+    const t0 = Date.now();
+    await service.getForPlayer('testnet', 'GHOST');
+    const elapsed = Date.now() - t0;
+
+    expect(elapsed).toBeLessThan(20);
+  });
+
+  it('benchmark result shape is consistent across repeated calls', async () => {
+    repo.find.mockResolvedValue([makeSession({ attemptsUsed: 2 })]);
+
+    const [r1, r2] = await Promise.all([
+      service.getForPlayer('testnet', 'GABC'),
+      service.getForPlayer('testnet', 'GABC'),
+    ]);
+
+    expect(r1.accrued).toBe(r2.accrued);
+    expect(r1.sessionCount).toBe(r2.sessionCount);
+    expect(r1.state).toBe(r2.state);
+  });
+
+  it('100-session batch: accrued is deterministic and > 0', async () => {
+    repo.find.mockResolvedValue(makeBatch(100));
+
+    const result = await service.getForPlayer('testnet', 'GABC');
+
+    expect(result.sessionCount).toBe(100);
+    expect(result.accrued).toBeGreaterThan(0);
+    expect(typeof result.accrued).toBe('number');
+    expect(Number.isFinite(result.accrued)).toBe(true);
+  });
+});

--- a/backend/src/indexer/registry-drift-snapshot.spec.ts
+++ b/backend/src/indexer/registry-drift-snapshot.spec.ts
@@ -1,0 +1,142 @@
+/**
+ * QA-215: Contract registry drift snapshot tests across frontend, backend, and SDK.
+ *
+ * These tests guard against silent divergence when a new contract topic is added
+ * to one consumer (e.g. the SDK event decoder) but not propagated to the others.
+ *
+ * Strategy:
+ *   - The canonical source-of-truth is ALLOWED_TOPICS in event-normalizer.service.ts.
+ *   - Inline "registry snapshots" represent what the frontend SDK and the frontend
+ *     lib would import if they were live modules. Tests fail immediately if:
+ *       (a) the BE normalizer accepts a topic that the FE/SDK snapshot does not know, or
+ *       (b) the FE/SDK snapshot claims a topic that the BE normalizer rejects.
+ *
+ * Extension guide: when a new contract event is added, update ALL THREE registries:
+ *   1. ALLOWED_TOPICS in event-normalizer.service.ts
+ *   2. FE_SDK_TOPICS below
+ *   3. FRONTEND_LIB_TOPICS below
+ */
+import { EventNormalizerService, ALLOWED_TOPICS } from './processors/event-normalizer.service';
+
+// ---------------------------------------------------------------------------
+// Inline registry snapshots (mirror what FE SDK / frontend lib export)
+// ---------------------------------------------------------------------------
+
+/** Topics the frontend SDK decoder is known to handle. */
+const FE_SDK_TOPICS = new Set([
+  'session_started',
+  'guess_submitted',
+  'session_finalized',
+  'reward_claimed',
+  'achievement_unlocked',
+]);
+
+/** Topics the frontend lib reads from projection-backed API responses. */
+const FRONTEND_LIB_TOPICS = new Set([
+  'session_started',
+  'guess_submitted',
+  'session_finalized',
+  'reward_claimed',
+  'achievement_unlocked',
+]);
+
+// ---------------------------------------------------------------------------
+// Healthy synchronized scenario
+// ---------------------------------------------------------------------------
+
+describe('QA-215: contract registry — healthy synchronized state', () => {
+  it('backend ALLOWED_TOPICS and FE SDK topics are identical (no drift)', () => {
+    const beTopics = [...ALLOWED_TOPICS].sort();
+    const sdkTopics = [...FE_SDK_TOPICS].sort();
+    expect(beTopics).toEqual(sdkTopics);
+  });
+
+  it('backend ALLOWED_TOPICS and frontend lib topics are identical (no drift)', () => {
+    const beTopics = [...ALLOWED_TOPICS].sort();
+    const libTopics = [...FRONTEND_LIB_TOPICS].sort();
+    expect(beTopics).toEqual(libTopics);
+  });
+
+  it('normalizer accepts every topic in the FE SDK snapshot', () => {
+    const normalizer = new EventNormalizerService();
+    for (const topic of FE_SDK_TOPICS) {
+      const event = normalizer.normalize('testnet', {
+        contractId: 'CTEST0000000000000000000000000000000000000000000000',
+        topic,
+        txHash: 'aabbccdd',
+        ledger: 100,
+        eventIndex: 0,
+        payload: { data: 'ok' },
+      });
+      expect(normalizer.isValid(event)).toBe(true);
+    }
+  });
+
+  it('all SDK topics normalise without mutation (lowercase passthrough)', () => {
+    const normalizer = new EventNormalizerService();
+    for (const topic of FE_SDK_TOPICS) {
+      const event = normalizer.normalize('testnet', {
+        contractId: 'CTEST0000000000000000000000000000000000000000000000',
+        topic: topic.toUpperCase(),
+        txHash: 'aabbccdd',
+        ledger: 100,
+        eventIndex: 0,
+      });
+      expect(event.topic).toBe(topic);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Mismatch / drift scenario
+// ---------------------------------------------------------------------------
+
+describe('QA-215: contract registry — drift detection', () => {
+  it('detects a topic added to SDK but not yet to the BE normalizer', () => {
+    // Simulate drift: SDK knows about a new topic the BE has not added yet
+    const driftedSdkTopics = new Set([...FE_SDK_TOPICS, 'streak_reset']);
+
+    const unregisteredInBE = [...driftedSdkTopics].filter(
+      (t) => !ALLOWED_TOPICS.has(t),
+    );
+    expect(unregisteredInBE).toContain('streak_reset');
+  });
+
+  it('detects a topic removed from SDK but still in BE allowlist', () => {
+    // Simulate drift: SDK dropped a topic the BE still accepts
+    const staleSdkTopics = new Set([...FE_SDK_TOPICS]);
+    staleSdkTopics.delete('achievement_unlocked');
+
+    const orphanedInBE = [...ALLOWED_TOPICS].filter((t) => !staleSdkTopics.has(t));
+    expect(orphanedInBE).toContain('achievement_unlocked');
+  });
+
+  it('normalizer rejects a topic not in any registry (unknown contract event)', () => {
+    const normalizer = new EventNormalizerService();
+    const event = normalizer.normalize('testnet', {
+      contractId: 'CTEST0000000000000000000000000000000000000000000000',
+      topic: 'contract_upgraded', // hypothetical future topic — not yet registered
+      txHash: 'aabbccdd',
+      ledger: 100,
+      eventIndex: 0,
+    });
+    expect(normalizer.isValid(event)).toBe(false);
+    expect(FE_SDK_TOPICS.has('contract_upgraded')).toBe(false);
+    expect(FRONTEND_LIB_TOPICS.has('contract_upgraded')).toBe(false);
+  });
+
+  it('snapshot comparison function surfaces diff set correctly', () => {
+    function registryDiff(a: Set<string>, b: Set<string>) {
+      return {
+        onlyInA: [...a].filter((t) => !b.has(t)),
+        onlyInB: [...b].filter((t) => !a.has(t)),
+      };
+    }
+
+    const simulatedBE = new Set([...ALLOWED_TOPICS, 'new_event']);
+    const { onlyInA, onlyInB } = registryDiff(simulatedBE, FE_SDK_TOPICS);
+
+    expect(onlyInA).toContain('new_event');
+    expect(onlyInB).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
Adds two QA test suites to the indexer test surface:

**QA-215 — Contract registry drift snapshot tests** (`registry-drift-snapshot.spec.ts`)
Inline registry snapshots for backend, frontend SDK, and frontend lib. Tests detect silent topic divergence across all three consumers — both a healthy-synchronized scenario and an explicit mismatch scenario.

**QA-217 — Read-model endpoint performance smoke benchmarks** (`performance-smoke.spec.ts`)
Measures wall-clock latency of projection-backed service calls under mocked I/O. Establishes a deterministic regression baseline that fails immediately if application logic grows unbounded.

closes #812
closes #814