### PR TITLE
Fix add standardized issue handoff checklist template

### DIFF
--- a/.github/ISSUE_TEMPLATE/handoff_checklist.yml
+++ b/.github/ISSUE_TEMPLATE/handoff_checklist.yml
@@ -1,0 +1,48 @@
+name: Issue Handoff Checklist
+description: Checklist for partially completed work to reduce stalled contributor threads
+labels: ["type:handoff", "needs-triage"]
+body:
+  - type: textarea
+    id: original_issue
+    attributes:
+      label: Original Issue
+      description: Link to the original issue being handed off.
+      placeholder: "Closes #<issue-number>"
+    validations:
+      required: true
+  - type: textarea
+    id: current_status
+    attributes:
+      label: Current Status
+      description: What has been completed so far.
+    validations:
+      required: true
+  - type: textarea
+    id: remaining_work
+    attributes:
+      label: Remaining Work
+      description: What still needs to be done.
+    validations:
+      required: true
+  - type: textarea
+    id: blockers
+    attributes:
+      label: Blockers
+      description: Any blockers or dependencies preventing completion.
+  - type: textarea
+    id: files_changed
+    attributes:
+      label: Files Changed
+      description: List all files modified or created so far.
+    validations:
+      required: true
+  - type: textarea
+    id: validation_evidence
+    attributes:
+      label: Validation Evidence
+      description: Commands run and outcomes (lint, tests, build).
+  - type: textarea
+    id: context_notes
+    attributes:
+      label: Context Notes
+      description: Any additional context, decisions made, or gotchas.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,3 +56,6 @@ The `/onchain/` directory contains outdated legacy code and is no longer maintai
 
 ## Wave Readiness
 Use `docs/WAVE_MIGRATION_ISSUE_CANDIDATES.md` and `docs/SOROBAN_GITHUB_STRATEGY.md` for issue slicing and labels.
+
+## Issue Handoff
+If you need to hand off partially completed work, use the [Issue Handoff Checklist](./.github/ISSUE_TEMPLATE/handoff_checklist.yml) template and follow the [Handoff Process](./docs/wave/HANDOFF_CHECKLIST.md).

--- a/docs/wave/HANDOFF_CHECKLIST.md
+++ b/docs/wave/HANDOFF_CHECKLIST.md
@@ -1,0 +1,48 @@
+# Issue Handoff Checklist
+
+This document explains how to use the standardized issue handoff checklist when transferring partially completed work between contributors.
+
+## Purpose
+
+Reduce stalled contributor threads by providing a structured handoff process that captures all necessary context.
+
+## When to Use
+
+- Contributor is leaving the project or going on leave
+- Contributor is stuck and needs help
+- Issue scope changed and original contributor cannot continue
+- Maintainer reassigns issue to a different contributor
+
+## Handoff Process
+
+1. **Open a Handoff Issue** using the `Issue Handoff Checklist` template.
+2. **Fill in all required fields** — do not leave sections empty.
+3. **Link the original issue** in the "Original Issue" field.
+4. **Close the original issue** with a comment linking to the handoff issue.
+5. **Assign the new contributor** to the handoff issue.
+
+## Checklist Fields
+
+| Field | Required | Description |
+|---|---|---|
+| Original Issue | Yes | Link to the original issue being handed off |
+| Current Status | Yes | What has been completed so far |
+| Remaining Work | Yes | What still needs to be done |
+| Blockers | No | Any blockers or dependencies preventing completion |
+| Files Changed | Yes | List all files modified or created so far |
+| Validation Evidence | No | Commands run and outcomes |
+| Context Notes | No | Additional context, decisions, or gotchas |
+
+## Handoff Quality Standards
+
+- Be specific about what is done vs. what remains.
+- Include exact file paths and line numbers where relevant.
+- List all commands that have been run and their outcomes.
+- Note any architectural decisions made during the work.
+- Flag any potential issues the next contributor should watch for.
+
+## Related Documentation
+
+- [Wave 5 Issue Tracks](./WAVE5_ISSUE_TRACKS.md)
+- [Contributing Guide](../../CONTRIBUTING.md)
+- [Wave Glossary](./WAVE_GLOSSARY.md)


### PR DESCRIPTION
## Summary

Created a handoff checklist for partially completed work to reduce stalled contributor threads while maintaining the existing architecture and coding standards.

### Changes

- Added `.github/ISSUE_TEMPLATE/handoff_checklist.yml` with structured fields for handoff context
- Added `docs/wave/HANDOFF_CHECKLIST.md` explaining the handoff process
- Updated `CONTRIBUTING.md` with handoff process link
- Template includes: original issue, current status, remaining work, blockers, files changed, validation evidence, context notes
- Template accepted and linked in contributing docs

Closes #673
Closes #671 
Closes #672 
Closes #674 