### PR TITLE
Deploy manifest generator, release simulation, secret-scan governance, cheat-sheet (#667-#670)

### DIFF
--- a/docs/CONTRIBUTOR_CHEATSHEET.md
+++ b/docs/CONTRIBUTOR_CHEATSHEET.md
@@ -1,0 +1,47 @@
+# Contributor Command Cheat-Sheet (issue #670)
+
+Quick reference for the daily contributor loop, grouped by track.
+
+## All tracks
+
+```bash
+npm run install:all   # install backend + frontend deps
+npm run lint          # lint backend + frontend
+npm run typecheck      # typecheck backend + frontend
+```
+
+## Frontend (FE)
+
+```bash
+npm run verify:frontend   # install, lint, typecheck, build, test
+```
+
+## Backend (BE)
+
+```bash
+npm run verify:backend    # install, build, typecheck, lint:ci, test:ci
+npm run test:e2e
+```
+
+## Smart Contracts (SC)
+
+```bash
+npm run soroban:check     # cargo check --workspace
+npm run soroban:fmt       # cargo fmt --all
+```
+
+## QA / DevOps
+
+```bash
+./scripts/ci-local.sh         # run local CI equivalent
+./scripts/validate-phase3.sh  # phase validation checks
+```
+
+## DX
+
+```bash
+npm run bootstrap          # contributor environment bootstrap
+npm run docs:linkcheck      # scan markdown for stale links
+```
+
+See `CONTRIBUTING.md` for the full first-PR checklist.

--- a/scripts/check-secret-scan-exceptions.js
+++ b/scripts/check-secret-scan-exceptions.js
@@ -1,0 +1,47 @@
+#!/usr/bin/env node
+/**
+ * Secret-Scan Exception Governance (issue #669)
+ *
+ * Reads a JSON list of approved secret-scan exceptions and fails when any
+ * has expired, forcing periodic re-review instead of silent indefinite
+ * suppression.
+ *
+ * Usage:
+ *   node scripts/check-secret-scan-exceptions.js [path-to-exceptions.json]
+ *
+ * Exceptions file shape:
+ *   [{ "rule": "generic-api-key", "path": "fixtures/sample.env", "expires": "2026-08-01" }]
+ */
+"use strict";
+const fs = require("fs");
+
+function findExpired(exceptions, now = new Date()) {
+  return exceptions.filter((entry) => new Date(entry.expires) < now);
+}
+
+function main() {
+  const file = process.argv[2] || "docs/security/secret-scan-exceptions.json";
+  if (!fs.existsSync(file)) {
+    console.log(`No exceptions file at ${file}; nothing to govern.`);
+    return;
+  }
+
+  const exceptions = JSON.parse(fs.readFileSync(file, "utf8"));
+  const expired = findExpired(exceptions);
+
+  if (expired.length > 0) {
+    console.error("Expired secret-scan exceptions require re-review:");
+    for (const entry of expired) {
+      console.error(`  - ${entry.rule} (${entry.path}) expired ${entry.expires}`);
+    }
+    process.exit(1);
+  }
+
+  console.log(`All ${exceptions.length} secret-scan exceptions are within their review window.`);
+}
+
+if (require.main === module) {
+  main();
+}
+
+module.exports = { findExpired };

--- a/scripts/simulate-release-pipeline.js
+++ b/scripts/simulate-release-pipeline.js
@@ -1,0 +1,41 @@
+#!/usr/bin/env node
+/**
+ * Release Pipeline Simulation (issue #668)
+ *
+ * Dry-run gate check across FE/BE/SC deliverables for M6 readiness.
+ * Reads component readiness from env flags (wired to real checks later)
+ * and prints a pass/fail simulation report per component.
+ *
+ * Usage:
+ *   FE_READY=true BE_READY=true SC_READY=false node scripts/simulate-release-pipeline.js
+ */
+"use strict";
+
+const COMPONENTS = ["FE", "BE", "SC"];
+
+function buildReport(env) {
+  const gates = COMPONENTS.map((name) => ({
+    component: name,
+    ready: env[`${name}_READY`] === "true",
+  }));
+
+  const overallReady = gates.every((g) => g.ready);
+
+  return { gates, overallReady };
+}
+
+function main() {
+  const report = buildReport(process.env);
+  console.log(JSON.stringify(report, null, 2));
+  if (!report.overallReady) {
+    console.error("Release simulation failed: one or more components not ready.");
+    process.exit(1);
+  }
+  console.log("Release simulation passed: all components ready.");
+}
+
+if (require.main === module) {
+  main();
+}
+
+module.exports = { buildReport };

--- a/soroban/scripts/deploy/generate-manifest.js
+++ b/soroban/scripts/deploy/generate-manifest.js
@@ -1,0 +1,54 @@
+#!/usr/bin/env node
+/**
+ * Deploy Manifest Generator (issue #667)
+ *
+ * Writes a versioned manifest of deployed contract ids and network
+ * metadata so the SDK loader can resolve a specific registry snapshot.
+ *
+ * Usage:
+ *   ADMIN_REGISTRY_ID=... CORE_GAME_ID=... REWARDS_ID=... ACHIEVEMENTS_ID=... \
+ *   NETWORK=testnet node soroban/scripts/deploy/generate-manifest.js
+ */
+"use strict";
+const fs = require("fs");
+const path = require("path");
+
+function buildManifest(env) {
+  const network = env.NETWORK || "testnet";
+  const required = ["ADMIN_REGISTRY_ID", "CORE_GAME_ID", "REWARDS_ID", "ACHIEVEMENTS_ID"];
+  const missing = required.filter((key) => !env[key]);
+  if (missing.length > 0) {
+    throw new Error(`Missing required env vars: ${missing.join(", ")}`);
+  }
+
+  return {
+    version: 1,
+    network,
+    generatedAt: new Date().toISOString(),
+    contracts: {
+      admin_registry: env.ADMIN_REGISTRY_ID,
+      core_game: env.CORE_GAME_ID,
+      rewards: env.REWARDS_ID,
+      achievements: env.ACHIEVEMENTS_ID,
+    },
+  };
+}
+
+function main() {
+  const manifest = buildManifest(process.env);
+  const outDir = path.join(__dirname);
+  const outFile = path.join(outDir, `manifest.${manifest.network}.json`);
+  fs.writeFileSync(outFile, JSON.stringify(manifest, null, 2) + "\n");
+  console.log(`Wrote ${outFile}`);
+}
+
+if (require.main === module) {
+  try {
+    main();
+  } catch (err) {
+    console.error(err.message);
+    process.exit(1);
+  }
+}
+
+module.exports = { buildManifest };


### PR DESCRIPTION
## Summary
- Adds `soroban/scripts/deploy/generate-manifest.js`: writes a versioned manifest (contract ids + network + timestamp) for the SDK loader to consume
- Adds `scripts/simulate-release-pipeline.js`: dry-run gate report across FE/BE/SC readiness flags for M6 readiness
- Adds `scripts/check-secret-scan-exceptions.js`: fails when a secret-scan exception has passed its expiry date
- Adds `docs/CONTRIBUTOR_CHEATSHEET.md`: per-track command reference for the daily contributor loop

Verified locally: all three scripts pass `node --check` and were run end-to-end (manifest generation, a failing release simulation, and the no-exceptions-file path all behaved as expected).

Closes #667
Closes #668
Closes #669
Closes #670