### PR TITLE
Event compat gate, stale-doc lint, reproducibility badge, branch-protection check (#659-#662)

### DIFF
--- a/.github/workflows/branch-protection-compliance.yml
+++ b/.github/workflows/branch-protection-compliance.yml
@@ -1,0 +1,38 @@
+name: Branch Protection Compliance
+
+on:
+  schedule:
+    - cron: "0 8 * * 1"
+  workflow_dispatch:
+
+jobs:
+  check-protection:
+    name: Verify main branch protection matches expectations
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Check required status checks on main
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          EXPECTED_CHECKS: "lint,typecheck,test"
+        run: |
+          set -euo pipefail
+          actual=$(gh api "repos/${{ github.repository }}/branches/main/protection" \
+            --jq '.required_status_checks.contexts | join(",")' 2>/dev/null || echo "")
+
+          missing=""
+          IFS=',' read -ra expected_arr <<< "$EXPECTED_CHECKS"
+          for check in "${expected_arr[@]}"; do
+            if [[ ",$actual," != *",$check,"* ]]; then
+              missing="$missing $check"
+            fi
+          done
+
+          if [[ -n "$missing" ]]; then
+            echo "::error::Branch protection drift on main. Missing required checks:$missing"
+            echo "Current contexts: $actual"
+            exit 1
+          fi
+
+          echo "Branch protection compliant. Required checks present: $actual"

--- a/scripts/contract-event-compat-gate.sh
+++ b/scripts/contract-event-compat-gate.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# Issue #659: fail CI when contract event surface changes without an
+# accompanying schema/SDK update, so breaking event changes can't slip in
+# silently.
+set -euo pipefail
+
+BASE_REF="${1:-origin/main}"
+
+contracts_changed=$(git diff --name-only "$BASE_REF"...HEAD -- soroban/contracts | wc -l | tr -d ' ')
+schema_changed=$(git diff --name-only "$BASE_REF"...HEAD -- soroban/sdk/ts/events.ts shared/events/schemas | wc -l | tr -d ' ')
+
+if [[ "$contracts_changed" -gt 0 && "$schema_changed" -eq 0 ]]; then
+  echo "ERROR: soroban/contracts changed ($contracts_changed file(s)) but no matching" >&2
+  echo "       update was made to soroban/sdk/ts/events.ts or shared/events/schemas." >&2
+  echo "       Update the event schema/SDK or confirm this change doesn't affect" >&2
+  echo "       declared event topics/payloads." >&2
+  exit 1
+fi
+
+echo "Contract event compatibility gate passed ($contracts_changed contract file(s), $schema_changed schema file(s) changed)."

--- a/scripts/docs-stale-issue-lint.js
+++ b/scripts/docs-stale-issue-lint.js
@@ -1,0 +1,60 @@
+#!/usr/bin/env node
+/**
+ * Wave Docs Stale-Issue Lint (issue #660)
+ *
+ * Scans docs/wave/*.md for `#<number>` issue references and flags any that
+ * no longer exist (deleted/renumbered), catching stale planning references.
+ *
+ * Usage:
+ *   node scripts/docs-stale-issue-lint.js
+ * Required env vars:
+ *   GITHUB_TOKEN, GITHUB_REPO (owner/repo)
+ */
+"use strict";
+const fs = require("fs");
+const path = require("path");
+
+function extractIssueRefs(text) {
+  const matches = text.matchAll(/#(\d+)/g);
+  return [...new Set([...matches].map((m) => Number(m[1])))];
+}
+
+async function issueExists(repo, token, number) {
+  const res = await fetch(`https://api.github.com/repos/${repo}/issues/${number}`, {
+    headers: { Authorization: `Bearer ${token}`, Accept: "application/vnd.github+json" },
+  });
+  return res.status !== 404;
+}
+
+async function main() {
+  const token = process.env.GITHUB_TOKEN;
+  const repo = process.env.GITHUB_REPO;
+  if (!token || !repo) throw new Error("GITHUB_TOKEN and GITHUB_REPO are required");
+
+  const dir = path.join("docs", "wave");
+  const files = fs.readdirSync(dir).filter((f) => f.endsWith(".md"));
+
+  const stale = [];
+  for (const file of files) {
+    const text = fs.readFileSync(path.join(dir, file), "utf8");
+    for (const num of extractIssueRefs(text)) {
+      if (!(await issueExists(repo, token, num))) stale.push({ file, number: num });
+    }
+  }
+
+  if (stale.length > 0) {
+    console.error("Stale issue references found:");
+    for (const s of stale) console.error(`  - ${s.file}: #${s.number}`);
+    process.exit(1);
+  }
+  console.log(`No stale issue references across ${files.length} wave doc(s).`);
+}
+
+if (require.main === module) {
+  main().catch((err) => {
+    console.error(err.message);
+    process.exit(1);
+  });
+}
+
+module.exports = { extractIssueRefs };

--- a/scripts/generate-repro-badge.js
+++ b/scripts/generate-repro-badge.js
@@ -1,0 +1,63 @@
+#!/usr/bin/env node
+/**
+ * Reproducibility Badge Generator (issue #661)
+ *
+ * Computes a recent CI success rate and writes a shields.io "endpoint"
+ * badge JSON file for contributor confidence at a glance.
+ *
+ * Usage:
+ *   node scripts/generate-repro-badge.js
+ * Required env vars:
+ *   GITHUB_TOKEN, GITHUB_REPO
+ * Optional:
+ *   RUN_LIMIT (default 30), OUT_FILE (default docs/badge-repro.json)
+ */
+"use strict";
+const fs = require("fs");
+
+function badgeColor(rate) {
+  if (rate >= 90) return "brightgreen";
+  if (rate >= 75) return "yellow";
+  return "red";
+}
+
+function buildBadge(runs) {
+  const completed = runs.filter((r) => r.conclusion);
+  const successes = completed.filter((r) => r.conclusion === "success").length;
+  const rate = completed.length === 0 ? 0 : Math.round((successes / completed.length) * 100);
+
+  return {
+    schemaVersion: 1,
+    label: "reproducibility",
+    message: `${rate}%`,
+    color: badgeColor(rate),
+  };
+}
+
+async function main() {
+  const token = process.env.GITHUB_TOKEN;
+  const repo = process.env.GITHUB_REPO;
+  const limit = Number(process.env.RUN_LIMIT || 30);
+  const outFile = process.env.OUT_FILE || "docs/badge-repro.json";
+  if (!token || !repo) throw new Error("GITHUB_TOKEN and GITHUB_REPO are required");
+
+  const res = await fetch(
+    `https://api.github.com/repos/${repo}/actions/runs?per_page=${limit}`,
+    { headers: { Authorization: `Bearer ${token}`, Accept: "application/vnd.github+json" } },
+  );
+  if (!res.ok) throw new Error(`GitHub API error: ${res.status}`);
+  const { workflow_runs: runs } = await res.json();
+
+  const badge = buildBadge(runs);
+  fs.writeFileSync(outFile, JSON.stringify(badge, null, 2) + "\n");
+  console.log(`Wrote ${outFile}: ${badge.message}`);
+}
+
+if (require.main === module) {
+  main().catch((err) => {
+    console.error(err.message);
+    process.exit(1);
+  });
+}
+
+module.exports = { buildBadge, badgeColor };


### PR DESCRIPTION
## Summary
- Adds `scripts/contract-event-compat-gate.sh`: fails when `soroban/contracts` changes without a matching update to `soroban/sdk/ts/events.ts` or `shared/events/schemas`
- Adds `scripts/docs-stale-issue-lint.js`: scans `docs/wave/*.md` for `#issue` references and flags any that no longer exist via the GitHub API
- Adds `scripts/generate-repro-badge.js`: computes a shields.io-compatible reproducibility badge from recent workflow run success rate
- Adds `.github/workflows/branch-protection-compliance.yml`: scheduled workflow reporting drift between `main`'s required status checks and the expected list

Verified locally: the shell script passes `bash -n` and a dry run against the current branch; both Node scripts pass `node --check` plus unit tests of their pure helper functions (`buildBadge`, `badgeColor`, `extractIssueRefs`); the workflow YAML parses.

Closes #659
Closes #660
Closes #661
Closes #662